### PR TITLE
Obsolete deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -346,6 +346,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-crate"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17d47ce914bf4de440332250b0edd23ce48c005f59fab39d3335866b114f11a"
+dependencies = [
+ "thiserror",
+ "toml",
+]
+
+[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -590,6 +600,7 @@ dependencies = [
  "convert_case",
  "cosmwasm-std",
  "cw-storage-plus",
+ "proc-macro-crate",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -628,6 +639,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "toml"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -481,15 +481,8 @@ dependencies = [
 [[package]]
 name = "serde-cw-value"
 version = "0.7.0"
-source = "git+https://github.com/CosmWasm/serde-cw-value.git#9a141c181a7b661556857dea0f736dd3272c775d"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "serde-cw-value"
-version = "0.7.0"
-source = "git+https://github.com/hashedone/serde-cw-value.git#9a141c181a7b661556857dea0f736dd3272c775d"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75d32da6b8ed758b7d850b6c3c08f1d7df51a4df3cb201296e63e34a78e99d4"
 dependencies = [
  "serde",
 ]
@@ -588,7 +581,7 @@ dependencies = [
  "cosmwasm-std",
  "schemars",
  "serde",
- "serde-cw-value 0.7.0 (git+https://github.com/hashedone/serde-cw-value.git)",
+ "serde-cw-value",
  "sylvia-derive",
 ]
 
@@ -606,7 +599,7 @@ dependencies = [
  "quote",
  "schemars",
  "serde",
- "serde-cw-value 0.7.0 (git+https://github.com/CosmWasm/serde-cw-value.git)",
+ "sylvia",
  "syn",
 ]
 

--- a/sylvia-derive/Cargo.toml
+++ b/sylvia-derive/Cargo.toml
@@ -22,9 +22,9 @@ proc-macro-error = "1"
 proc-macro-crate = "1.1"
 
 [dev-dependencies]
-serde-cw-value = { version = "0.7.0", git = "https://github.com/CosmWasm/serde-cw-value.git" }
 serde = { version = "1", features = ["derive"] }
 cosmwasm-std = "1"
 cw-storage-plus = "0.13.2"
 schemars = "0.8"
 anyhow = "1"
+sylvia = { version = "0.1.1", path = "../sylvia" }

--- a/sylvia-derive/Cargo.toml
+++ b/sylvia-derive/Cargo.toml
@@ -19,6 +19,7 @@ quote = "1"
 proc-macro2 = "1"
 convert_case = "0.5"
 proc-macro-error = "1"
+proc-macro-crate = "1.1"
 
 [dev-dependencies]
 serde-cw-value = { version = "0.7.0", git = "https://github.com/CosmWasm/serde-cw-value.git" }

--- a/sylvia-derive/examples/basic.rs
+++ b/sylvia-derive/examples/basic.rs
@@ -2,15 +2,29 @@
 use anyhow::Error;
 use cosmwasm_std::{Addr, Deps, DepsMut, Env, MessageInfo, Response, StdError};
 use cw_storage_plus::{Item, Map};
-use sylvia_derive::{contract, interface};
+use sylvia::{contract, interface};
 
-#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq, schemars::JsonSchema)]
+#[derive(
+    sylvia::serde::Serialize,
+    sylvia::serde::Deserialize,
+    Clone,
+    Debug,
+    PartialEq,
+    sylvia::schemars::JsonSchema,
+)]
 pub struct Member {
     addr: String,
     weight: u64,
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq, schemars::JsonSchema)]
+#[derive(
+    sylvia::serde::Serialize,
+    sylvia::serde::Deserialize,
+    Clone,
+    Debug,
+    PartialEq,
+    sylvia::schemars::JsonSchema,
+)]
 pub struct MemberResp {
     weight: u64,
 }

--- a/sylvia-derive/src/message.rs
+++ b/sylvia-derive/src/message.rs
@@ -1,4 +1,5 @@
 use crate::check_generics::CheckGenerics;
+use crate::crate_module;
 use crate::parser::{ContractMessageAttr, InterfaceArgs, MsgAttr, MsgType};
 use crate::strip_generics::StripGenerics;
 use convert_case::{Case, Casing};
@@ -144,6 +145,8 @@ impl<'a> StructMessage<'a> {
     }
 
     pub fn emit_struct(&self, name: &Ident) -> TokenStream {
+        let sylvia = crate_module();
+
         let Self {
             contract_type,
             fields,
@@ -185,7 +188,7 @@ impl<'a> StructMessage<'a> {
         };
 
         quote! {
-            #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq, schemars::JsonSchema)]
+            #[derive(#sylvia ::serde::Serialize, #sylvia ::serde::Deserialize, Clone, Debug, PartialEq, #sylvia ::schemars::JsonSchema)]
             #[serde(rename_all="snake_case")]
             pub struct #name #generics #where_clause {
                 #(pub #fields,)*
@@ -270,6 +273,8 @@ impl<'a> EnumMessage<'a> {
     }
 
     pub fn emit(&self) -> TokenStream {
+        let sylvia = crate_module();
+
         let Self {
             name,
             trait_name,
@@ -311,7 +316,7 @@ impl<'a> EnumMessage<'a> {
         };
 
         quote! {
-            #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq, schemars::JsonSchema)]
+            #[derive(#sylvia ::serde::Serialize, #sylvia ::serde::Deserialize, Clone, Debug, PartialEq, #sylvia ::schemars::JsonSchema)]
             #[serde(rename_all="snake_case")]
             pub enum #name #generics #where_clause {
                 #(#variants,)*
@@ -511,6 +516,8 @@ impl<'a> GlueMessage<'a> {
     }
 
     pub fn emit(&self) -> TokenStream {
+        let sylvia = crate_module();
+
         let Self {
             interfaces,
             name,
@@ -568,7 +575,7 @@ impl<'a> GlueMessage<'a> {
         let ret_type = msg_ty.emit_result_type(&None, error);
 
         quote! {
-            #[derive(serde::Serialize, Clone, Debug, PartialEq, schemars::JsonSchema)]
+            #[derive(#sylvia ::serde::Serialize, Clone, Debug, PartialEq, #sylvia ::schemars::JsonSchema)]
             #[serde(rename_all="snake_case")]
             pub enum #name {
                 #(#variants,)*
@@ -592,7 +599,7 @@ impl<'a> GlueMessage<'a> {
                     where D: serde::Deserializer<'de>,
                 {
                     use serde::de::Error;
-                    let val = serde_cw_value::Value::deserialize(deserializer)?;
+                    let val = #sylvia ::serde_value::Value::deserialize(deserializer)?;
 
                     #(#deserialization_attempts)*
 

--- a/sylvia-derive/src/parser.rs
+++ b/sylvia-derive/src/parser.rs
@@ -4,6 +4,8 @@ use syn::parse::{Error, Nothing, Parse, ParseBuffer, ParseStream};
 use syn::punctuated::Punctuated;
 use syn::{parenthesized, parse2, parse_quote, Ident, Path, Result, Token, Type};
 
+use crate::crate_module;
+
 /// Parsed arguments for `interface` macro
 pub struct InterfaceArgs {
     /// Module name wrapping generated messages, by default no additional module is created
@@ -129,16 +131,18 @@ impl MsgType {
     pub fn emit_result_type(self, msg_type: &Option<Type>, err_type: &Type) -> TokenStream {
         use MsgType::*;
 
+        let sylvia = crate_module();
+
         match (self, msg_type) {
             (Exec, Some(msg_type)) | (Instantiate, Some(msg_type)) => quote! {
-                std::result::Result<cosmwasm_std::Response<#msg_type>, #err_type>
+                std::result::Result<#sylvia ::cw_std::Response<#msg_type>, #err_type>
             },
             (Exec, None) | (Instantiate, None) => quote! {
-                std::result::Result<cosmwasm_std::Response, #err_type>
+                std::result::Result<#sylvia ::cw_std::Response, #err_type>
             },
 
             (Query, _) => quote! {
-                std::result::Result<cosmwasm_std::Binary, #err_type>
+                std::result::Result<#sylvia ::cw_std::Binary, #err_type>
             },
         }
     }

--- a/sylvia/Cargo.toml
+++ b/sylvia/Cargo.toml
@@ -16,4 +16,4 @@ sylvia-derive = { path = "../sylvia-derive" }
 cosmwasm-std = { version = "1", features = ["staking"] }
 schemars = "0.8.10"
 serde = { version = "1", default-features = false, features = ["derive"] }
-serde-cw-value = { version = "0.7.0", git = "https://github.com/hashedone/serde-cw-value.git" }
+serde-cw-value = "0.7.0"


### PR DESCRIPTION
Changed all generated code dependencies to use `sylvia` reexports.

`schemars` and `serde` still have to be included as contract dependency, because serde and schemars derive macros are using them in their generated code, but they never have to be used directly.