### PR TITLE
Adding Eq trait in few places with clippy.

### DIFF
--- a/sylvia-derive/src/parser.rs
+++ b/sylvia-derive/src/parser.rs
@@ -99,7 +99,7 @@ impl Parse for Mapping {
 }
 
 /// Type of message to be generated
-#[derive(PartialEq, Debug, Clone, Copy)]
+#[derive(PartialEq, Eq, Debug, Clone, Copy)]
 pub enum MsgType {
     Exec,
     Query,

--- a/sylvia/examples/basic.rs
+++ b/sylvia/examples/basic.rs
@@ -9,7 +9,7 @@ use sylvia::{contract, interface};
     sylvia::serde::Deserialize,
     Clone,
     Debug,
-    PartialEq,
+    PartialEq, Eq,
     sylvia::schemars::JsonSchema,
 )]
 pub struct Member {
@@ -22,7 +22,7 @@ pub struct Member {
     sylvia::serde::Deserialize,
     Clone,
     Debug,
-    PartialEq,
+    PartialEq, Eq,
     sylvia::schemars::JsonSchema,
 )]
 pub struct MemberResp {

--- a/sylvia/tests/dispatching.rs
+++ b/sylvia/tests/dispatching.rs
@@ -40,11 +40,11 @@ struct Contract {
     data: RefCell<HashMap<Addr, QueryResponse>>,
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub struct EmptyQueryResponse {}
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub struct QueryResponse {
     coef: Decimal,

--- a/sylvia/tests/generics_dispatching.rs
+++ b/sylvia/tests/generics_dispatching.rs
@@ -40,7 +40,7 @@ impl From<StdError> for Error {
     }
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub struct QueryResponse<T> {
     data: T,

--- a/sylvia/tests/messages_generation.rs
+++ b/sylvia/tests/messages_generation.rs
@@ -2,7 +2,7 @@ use cosmwasm_std::{Addr, Decimal, Deps, DepsMut, Env, MessageInfo, Response, Std
 
 use sylvia::interface;
 
-#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq, schemars::JsonSchema)]
+#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq, Eq, schemars::JsonSchema)]
 pub struct QueryResult;
 
 #[interface]

--- a/sylvia/tests/separate_module.rs
+++ b/sylvia/tests/separate_module.rs
@@ -2,7 +2,7 @@ use cosmwasm_std::{Addr, Decimal, Deps, DepsMut, Env, MessageInfo, Response, Std
 
 use sylvia::interface;
 
-#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq, schemars::JsonSchema)]
+#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq, Eq, schemars::JsonSchema)]
 pub struct QueryResult;
 
 #[interface(module=msg)]


### PR DESCRIPTION
There are still some warnings with lack of Eq in interface
generated msgs. Unfortunately adding Eq there is not allowed
due std::cmp::Eq not being implemented for cosmwasm::CosmosMsg.