### PR TITLE
Additional attribute for entry points

### DIFF
--- a/contracts/cw1-subkeys/src/contract.rs
+++ b/contracts/cw1-subkeys/src/contract.rs
@@ -9,6 +9,9 @@ use cw_storage_plus::{Bound, Map};
 use cw_utils::Expiration;
 use sylvia::{contract, schemars};
 
+#[cfg(not(feature = "library"))]
+use sylvia::entry_points;
+
 use crate::error::ContractError;
 use crate::responses::{
     AllAllowancesResponse, AllPermissionsResponse, AllowanceInfo, PermissionsInfo,
@@ -28,7 +31,9 @@ pub struct Cw1SubkeysContract<'a> {
     pub(crate) allowances: Map<'static, &'a Addr, Allowance>,
 }
 
-#[contract(error=ContractError)]
+#[cfg_attr(not(feature = "library"), entry_points)]
+#[contract]
+#[error(ContractError)]
 #[messages(cw1 as Cw1)]
 #[messages(whitelist as Whitelist)]
 impl Cw1SubkeysContract<'_> {

--- a/contracts/cw1-subkeys/src/lib.rs
+++ b/contracts/cw1-subkeys/src/lib.rs
@@ -6,6 +6,3 @@ pub mod multitest;
 pub mod responses;
 pub mod state;
 mod whitelist;
-
-#[cfg(not(feature = "library"))]
-pub use crate::contract::entry_points::*;

--- a/contracts/cw1-whitelist/src/contract.rs
+++ b/contracts/cw1-whitelist/src/contract.rs
@@ -6,6 +6,9 @@ use cw2::set_contract_version;
 use cw_storage_plus::{Item, Map};
 use sylvia::{contract, schemars};
 
+#[cfg(not(feature = "library"))]
+use sylvia::entry_points;
+
 const CONTRACT_NAME: &str = env!("CARGO_PKG_NAME");
 const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
 
@@ -14,7 +17,9 @@ pub struct Cw1WhitelistContract<'a> {
     pub(crate) mutable: Item<'static, bool>,
 }
 
-#[contract(error=ContractError)]
+#[cfg_attr(not(feature = "library"), entry_points)]
+#[contract]
+#[error(ContractError)]
 #[messages(cw1 as Cw1)]
 #[messages(whitelist as Whitelist)]
 impl Cw1WhitelistContract<'_> {

--- a/contracts/cw1-whitelist/src/lib.rs
+++ b/contracts/cw1-whitelist/src/lib.rs
@@ -5,6 +5,3 @@ pub mod error;
 pub mod multitest;
 pub mod responses;
 pub mod whitelist;
-
-#[cfg(not(feature = "library"))]
-pub use crate::contract::entry_points::*;

--- a/contracts/cw20-base/Cargo.toml
+++ b/contracts/cw20-base/Cargo.toml
@@ -12,7 +12,7 @@ homepage = "https://cosmwasm.com"
 crate-type = ["cdylib", "rlib"]
 
 [features]
-library = ["sylvia/no_entry_points"]
+library = []
 tests = ["library", "cw-multi-test", "anyhow"]
 
 [dependencies]

--- a/contracts/cw20-base/src/contract.rs
+++ b/contracts/cw20-base/src/contract.rs
@@ -15,6 +15,9 @@ use cw_storage_plus::{Item, Map};
 use cw_utils::ensure_from_older_version;
 use sylvia::{contract, schemars};
 
+#[cfg(not(feature = "library"))]
+use sylvia::entry_points;
+
 // version info for migration info
 const CONTRACT_NAME: &str = "crates.io:cw20-base";
 const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -69,7 +72,9 @@ pub struct Cw20Base<'a> {
     pub(crate) allowances_spender: Map<'static, (&'a Addr, &'a Addr), AllowanceResponse>,
 }
 
-#[contract(error=ContractError)]
+#[cfg_attr(not(feature = "library"), entry_points)]
+#[contract]
+#[error(ContractError)]
 #[messages(cw20_allowances as Allowances)]
 #[messages(cw20_marketing as Marketing)]
 #[messages(cw20_minting as Minting)]

--- a/contracts/cw20-base/src/lib.rs
+++ b/contracts/cw20-base/src/lib.rs
@@ -8,6 +8,3 @@ pub mod validation;
 
 #[cfg(any(test, feature = "tests"))]
 mod multitest;
-
-#[cfg(not(feature = "library"))]
-pub use crate::contract::entry_points::*;

--- a/sylvia-derive/src/input.rs
+++ b/sylvia-derive/src/input.rs
@@ -1,11 +1,14 @@
 use proc_macro2::{Span, TokenStream};
 use proc_macro_error::emit_error;
 use quote::quote;
-use syn::{GenericParam, Ident, ItemImpl, ItemTrait, TraitItem};
+use syn::parse::{Parse, Parser};
+use syn::spanned::Spanned;
+use syn::{parse_quote, GenericParam, Ident, ItemImpl, ItemTrait, TraitItem, Type};
 
-use crate::message::{ContractEnumMessage, EntryPoints, EnumMessage, GlueMessage, StructMessage};
+use crate::crate_module;
+use crate::message::{ContractEnumMessage, EnumMessage, GlueMessage, StructMessage};
 use crate::multitest::{MultitestHelpers, TraitMultitestHelpers};
-use crate::parser::{ContractArgs, InterfaceArgs, MsgType};
+use crate::parser::{ContractArgs, ContractErrorAttr, InterfaceArgs, MsgType};
 
 /// Preprocessed `interface` macro input
 pub struct TraitInput<'a> {
@@ -17,6 +20,7 @@ pub struct TraitInput<'a> {
 /// Preprocessed `contract` macro input for non-trait impl block
 pub struct ImplInput<'a> {
     attributes: &'a ContractArgs,
+    error: Type,
     item: &'a ItemImpl,
     generics: Vec<&'a GenericParam>,
 }
@@ -103,12 +107,30 @@ impl<'a> TraitInput<'a> {
 
 impl<'a> ImplInput<'a> {
     pub fn new(attributes: &'a ContractArgs, item: &'a ItemImpl) -> Self {
+        let sylvia = crate_module();
+
         let generics = item.generics.params.iter().collect();
+
+        let error = item
+            .attrs
+            .iter()
+            .find(|attr| attr.path.is_ident("error"))
+            .and_then(
+                |attr| match ContractErrorAttr::parse.parse2(attr.tokens.clone()) {
+                    Ok(error) => Some(error.error),
+                    Err(err) => {
+                        emit_error!(attr.span(), err);
+                        None
+                    }
+                },
+            )
+            .unwrap_or(parse_quote! { #sylvia ::cw_std::StdError });
 
         Self {
             attributes,
             item,
             generics,
+            error,
         }
     }
 
@@ -116,8 +138,7 @@ impl<'a> ImplInput<'a> {
         let is_trait = self.item.trait_.is_some();
 
         let multitest_helpers = if cfg!(feature = "mt") {
-            MultitestHelpers::new(self.item, is_trait, &self.attributes.error, &self.generics)
-                .emit()
+            MultitestHelpers::new(self.item, is_trait, &self.error, &self.generics).emit()
         } else {
             quote! {}
         };
@@ -155,7 +176,6 @@ impl<'a> ImplInput<'a> {
             self.emit_enum_msg(&Ident::new("QueryMsg", Span::mixed_site()), MsgType::Query);
         let exec = self.emit_glue_msg(&Ident::new("ExecMsg", Span::mixed_site()), MsgType::Exec);
         let query = self.emit_glue_msg(&Ident::new("QueryMsg", Span::mixed_site()), MsgType::Query);
-        let entry_points = self.emit_entry_points();
 
         quote! {
             #instantiate
@@ -169,13 +189,7 @@ impl<'a> ImplInput<'a> {
             #exec
 
             #query
-
-            #entry_points
         }
-    }
-
-    fn emit_entry_points(&self) -> TokenStream {
-        EntryPoints::new(self.item, &self.attributes.error).emit()
     }
 
     fn emit_struct_msg(&self, msg_ty: MsgType) -> TokenStream {
@@ -183,10 +197,10 @@ impl<'a> ImplInput<'a> {
     }
 
     fn emit_enum_msg(&self, name: &Ident, msg_ty: MsgType) -> TokenStream {
-        ContractEnumMessage::new(name, self.item, msg_ty, &self.generics, self.attributes).emit()
+        ContractEnumMessage::new(name, self.item, msg_ty, &self.generics, &self.error).emit()
     }
 
     fn emit_glue_msg(&self, name: &Ident, msg_ty: MsgType) -> TokenStream {
-        GlueMessage::new(name, self.item, msg_ty, &self.attributes.error).emit()
+        GlueMessage::new(name, self.item, msg_ty, &self.error).emit()
     }
 }

--- a/sylvia-derive/src/message.rs
+++ b/sylvia-derive/src/message.rs
@@ -1,7 +1,7 @@
 use crate::check_generics::CheckGenerics;
 use crate::crate_module;
 use crate::parser::{
-    parse_struct_message, ContractArgs, ContractMessageAttr, InterfaceArgs, MsgAttr, MsgType,
+    parse_struct_message, ContractErrorAttr, ContractMessageAttr, InterfaceArgs, MsgAttr, MsgType,
 };
 use crate::strip_generics::StripGenerics;
 use crate::utils::{extract_return_type, filter_wheres, process_fields};
@@ -322,7 +322,7 @@ impl<'a> ContractEnumMessage<'a> {
         source: &'a ItemImpl,
         ty: MsgType,
         generics: &'a [&'a GenericParam],
-        args: &'a ContractArgs,
+        error: &'a Type,
     ) -> Self {
         let mut generics_checker = CheckGenerics::new(generics);
         let variants: Vec<_> = source
@@ -359,7 +359,7 @@ impl<'a> ContractEnumMessage<'a> {
             variants,
             msg_ty: ty,
             contract: &source.self_ty,
-            error: &args.error,
+            error,
         }
     }
 
@@ -847,22 +847,35 @@ impl<'a> GlueMessage<'a> {
     }
 }
 
-#[derive(Debug)]
-pub struct EntryPoints<'a> {
+pub struct EntryPoints {
     name: Type,
-    error: &'a Type,
+    error: Type,
 }
 
-impl<'a> EntryPoints<'a> {
-    pub fn new(source: &'a ItemImpl, error: &'a Type) -> Self {
+impl EntryPoints {
+    pub fn new(source: &ItemImpl) -> Self {
+        let sylvia = crate_module();
         let name = StripGenerics.fold_type(*source.self_ty.clone());
+
+        let error = source
+            .attrs
+            .iter()
+            .find(|attr| attr.path.is_ident("error"))
+            .and_then(
+                |attr| match ContractErrorAttr::parse.parse2(attr.tokens.clone()) {
+                    Ok(error) => Some(error.error),
+                    Err(err) => {
+                        emit_error!(attr.span(), err);
+                        None
+                    }
+                },
+            )
+            .unwrap_or(parse_quote! { #sylvia ::cw_std::StdError });
+
         Self { name, error }
     }
 
     pub fn emit(&self) -> TokenStream {
-        if cfg!(feature = "no_entry_points") {
-            return quote! {};
-        }
         let Self { name, error } = self;
         let sylvia = crate_module();
 

--- a/sylvia-derive/src/parser.rs
+++ b/sylvia-derive/src/parser.rs
@@ -3,10 +3,7 @@ use proc_macro_error::emit_error;
 use quote::quote;
 use syn::parse::{Error, Nothing, Parse, ParseBuffer, ParseStream, Parser};
 use syn::spanned::Spanned;
-use syn::{
-    parenthesized, parse_quote, Ident, ImplItem, ImplItemMethod, ItemImpl, Path, Result, Token,
-    Type,
-};
+use syn::{parenthesized, Ident, ImplItem, ImplItemMethod, ItemImpl, Path, Result, Token, Type};
 
 use crate::crate_module;
 
@@ -24,8 +21,6 @@ pub struct InterfaceArgs {
 pub struct ContractArgs {
     /// Module name wrapping generated messages, by default no additional module is created
     pub module: Option<Ident>,
-    /// The type of a contract error for entry points - `cosmwasm_std::StdError` by default
-    pub error: Type,
 }
 
 impl Parse for InterfaceArgs {
@@ -42,7 +37,7 @@ impl Parse for InterfaceArgs {
             } else if attr == "msg_type" {
                 msg_type = Some(input.parse()?);
             } else {
-                return Err(Error::new(attr.span(), "expected `module` or `msg_type`"));
+                return Err(Error::new(attr.span(), "expected `module`, or `msg_type`"));
             }
 
             if input.peek(Token![,]) {
@@ -61,7 +56,6 @@ impl Parse for InterfaceArgs {
 impl Parse for ContractArgs {
     fn parse(input: ParseStream) -> Result<Self> {
         let mut module = None;
-        let mut error = parse_quote!(cosmwasm_std::StdError);
 
         while !input.is_empty() {
             let attr: Ident = input.parse()?;
@@ -69,10 +63,8 @@ impl Parse for ContractArgs {
 
             if attr == "module" {
                 module = Some(input.parse()?);
-            } else if attr == "error" {
-                error = input.parse()?;
             } else {
-                return Err(Error::new(attr.span(), "expected `module` or `error`"));
+                return Err(Error::new(attr.span(), "expected `module`"));
             }
 
             if input.peek(Token![,]) {
@@ -84,7 +76,7 @@ impl Parse for ContractArgs {
 
         let _: Nothing = input.parse()?;
 
-        Ok(ContractArgs { module, error })
+        Ok(ContractArgs { module })
     }
 }
 
@@ -198,6 +190,22 @@ impl Parse for MsgAttr {
                 "Invalid message type, expected one of: `exec`, `query`, `instantiate`, `migrate`",
             ))
         }
+    }
+}
+
+#[derive(Debug)]
+pub struct ContractErrorAttr {
+    pub error: Type,
+}
+
+#[cfg(not(tarpaulin_include))]
+// False negative. It is being called in closure
+impl Parse for ContractErrorAttr {
+    fn parse(input: ParseStream) -> Result<Self> {
+        let content;
+        parenthesized!(content in input);
+
+        content.parse().map(|error| Self { error })
     }
 }
 

--- a/sylvia-derive/src/strip_input.rs
+++ b/sylvia-derive/src/strip_input.rs
@@ -57,7 +57,7 @@ impl Fold for StripInput {
         let attrs = i
             .attrs
             .into_iter()
-            .filter(|attr| !attr.path.is_ident("messages"))
+            .filter(|attr| !(attr.path.is_ident("messages") || attr.path.is_ident("error")))
             .collect();
 
         fold::fold_item_impl(self, ItemImpl { attrs, ..i })

--- a/sylvia/examples/basic.rs
+++ b/sylvia/examples/basic.rs
@@ -93,7 +93,8 @@ impl Group for GroupContract {
     }
 }
 
-#[contract(module=contract, error=Error)]
+#[contract(module=contract)]
+#[error(Error)]
 #[messages(group as Group)]
 impl GroupContract {
     pub const fn new() -> Self {

--- a/sylvia/src/lib.rs
+++ b/sylvia/src/lib.rs
@@ -15,4 +15,4 @@ pub use schemars;
 pub use serde;
 pub use serde_cw_value as serde_value;
 pub use serde_json_wasm as serde_json;
-pub use sylvia_derive::{contract, interface};
+pub use sylvia_derive::{contract, entry_points, interface};

--- a/sylvia/tests/messages_generation.rs
+++ b/sylvia/tests/messages_generation.rs
@@ -34,7 +34,7 @@ pub struct Contract {}
 
 #[cfg(not(tarpaulin_include))]
 // Ignoring coverage of test implementation
-#[contract(module=contract, error=StdError)]
+#[contract(module=contract)]
 impl Contract {
     #[allow(clippy::new_without_default)]
     pub const fn new() -> Self {

--- a/sylvia/tests/query_returns.rs
+++ b/sylvia/tests/query_returns.rs
@@ -26,7 +26,8 @@ pub trait Interface {
 
 pub struct SomeContract {}
 
-#[contract(error=ContractError)]
+#[contract]
+#[error(ContractError)]
 impl SomeContract {
     #[allow(clippy::new_without_default)]
     pub const fn new() -> Self {


### PR DESCRIPTION
The whole trick here is moving the entire entry points generation to its own macro.

This allows enabling/disabling it based on some criteria (like feature being enabled) with `cfg_attr`.

Then there is an intermediate problem - `ContractError` has to be somehow passed to the `entry_points` macro. We don't want to duplicate it.

The easiest solution is to move the `ContractError` definition. This allows you to read it by all the macros. The important thing is that the `entry_points` macro does not strip the internal attributes - the fact that attributes are evaluated top-to-bottom is used here. It only reads the attribute.

An additional step to be done is to do the same thing for `ContractError` for interfaces and for the `module` thingy - it would make it more consistent.