### PR TITLE
Fix for multitests generation

### DIFF
--- a/contracts/cw1-subkeys/src/multitest/tests.rs
+++ b/contracts/cw1-subkeys/src/multitest/tests.rs
@@ -370,7 +370,7 @@ mod permissions {
 }
 
 mod cw1_execute {
-    use crate::cw1::test_utils::Cw1Methods;
+    use crate::cw1::test_utils::Cw1;
     use cosmwasm_std::BankMsg;
 
     use super::*;

--- a/contracts/cw1-subkeys/src/whitelist.rs
+++ b/contracts/cw1-subkeys/src/whitelist.rs
@@ -1,8 +1,6 @@
 use cosmwasm_std::{Response, StdResult};
 use cw1_whitelist::responses::AdminListResponse;
-#[cfg(test)]
-use cw1_whitelist::whitelist;
-use cw1_whitelist::whitelist::Whitelist;
+use cw1_whitelist::whitelist::{self, Whitelist};
 use sylvia::contract;
 use sylvia::types::{ExecCtx, QueryCtx};
 

--- a/contracts/cw1-whitelist/src/multitest.rs
+++ b/contracts/cw1-whitelist/src/multitest.rs
@@ -3,11 +3,11 @@ mod test {
     use cosmwasm_std::{to_binary, WasmMsg};
 
     use crate::contract::multitest_utils::CodeId;
-    use crate::cw1::test_utils::Cw1Methods;
+    use crate::cw1::test_utils::Cw1;
     use crate::error::ContractError;
     use crate::responses::AdminListResponse;
     use crate::whitelist;
-    use crate::whitelist::test_utils::WhitelistMethods;
+    use crate::whitelist::test_utils::Whitelist;
     use assert_matches::assert_matches;
     use sylvia::multitest::App;
 

--- a/contracts/cw20-base/src/multitest/allowances_tests.rs
+++ b/contracts/cw20-base/src/multitest/allowances_tests.rs
@@ -7,7 +7,7 @@ use cw_multi_test::next_block;
 use cw_utils::Expiration;
 use sylvia::multitest::App;
 
-use crate::allowances::test_utils::Cw20AllowancesMethods;
+use crate::allowances::test_utils::Cw20Allowances;
 use crate::contract::multitest_utils::CodeId;
 use crate::contract::InstantiateMsgData;
 use crate::error::ContractError;

--- a/contracts/cw20-base/src/multitest/base_tests.rs
+++ b/contracts/cw20-base/src/multitest/base_tests.rs
@@ -3,7 +3,7 @@ use cw20_allowances::responses::{AllAllowancesResponse, SpenderAllowanceInfo};
 use cw_utils::Expiration;
 use sylvia::multitest::App;
 
-use crate::allowances::test_utils::Cw20AllowancesMethods;
+use crate::allowances::test_utils::Cw20Allowances;
 use crate::contract::multitest_utils::CodeId;
 use crate::contract::InstantiateMsgData;
 use crate::error::ContractError;

--- a/contracts/cw20-base/src/multitest/marketing_tests.rs
+++ b/contracts/cw20-base/src/multitest/marketing_tests.rs
@@ -6,7 +6,7 @@ use sylvia::multitest::App;
 use crate::contract::multitest_utils::CodeId;
 use crate::contract::{InstantiateMarketingInfo, InstantiateMsgData};
 use crate::error::ContractError;
-use crate::marketing::test_utils::Cw20MarketingMethods;
+use crate::marketing::test_utils::Cw20Marketing;
 
 const PNG_HEADER: [u8; 8] = [0x89, b'P', b'N', b'G', 0x0d, 0x0a, 0x1a, 0x0a];
 

--- a/contracts/cw20-base/src/multitest/minting_tests.rs
+++ b/contracts/cw20-base/src/multitest/minting_tests.rs
@@ -5,7 +5,7 @@ use sylvia::multitest::App;
 use crate::contract::multitest_utils::CodeId;
 use crate::contract::InstantiateMsgData;
 use crate::error::ContractError;
-use crate::minting::test_utils::Cw20MintingMethods;
+use crate::minting::test_utils::Cw20Minting;
 use crate::responses::{Cw20Coin, TokenInfoResponse};
 
 #[test]

--- a/sylvia-derive/src/multitest.rs
+++ b/sylvia-derive/src/multitest.rs
@@ -328,7 +328,7 @@ impl<'a> MultitestHelpers<'a> {
 
         let interface_name = interface_name(self.source);
         let proxy_name = &self.proxy_name;
-        let trait_name = Ident::new(&format!("{}Methods", interface_name), interface_name.span());
+        let trait_name = Ident::new(&format!("{}", interface_name), interface_name.span());
 
         let modules: Vec<_> = source
             .attrs
@@ -418,7 +418,6 @@ impl<'a> MultitestHelpers<'a> {
         });
 
         quote! {
-            #[cfg(test)]
             pub mod test_utils {
                 use super::*;
 

--- a/sylvia/examples/basic.rs
+++ b/sylvia/examples/basic.rs
@@ -31,23 +31,60 @@ pub struct MemberResp {
     weight: u64,
 }
 
-#[interface(module=group)]
-pub trait Group {
-    type Error: From<StdError>;
+mod group {
+    use super::*;
 
-    #[msg(exec)]
-    fn update_admin(&self, ctx: ExecCtx, admin: Option<String>) -> Result<Response, Self::Error>;
+    #[interface]
+    pub trait Group {
+        type Error: From<StdError>;
 
-    #[msg(exec)]
-    fn update_members(
-        &self,
-        ctx: ExecCtx,
-        remove: Vec<String>,
-        add: Vec<Member>,
-    ) -> Result<Response, Self::Error>;
+        #[msg(exec)]
+        fn update_admin(
+            &self,
+            ctx: ExecCtx,
+            admin: Option<String>,
+        ) -> Result<Response, Self::Error>;
 
-    #[msg(query)]
-    fn member(&self, ctx: QueryCtx, addr: String) -> Result<MemberResp, Self::Error>;
+        #[msg(exec)]
+        fn update_members(
+            &self,
+            ctx: ExecCtx,
+            remove: Vec<String>,
+            add: Vec<Member>,
+        ) -> Result<Response, Self::Error>;
+
+        #[msg(query)]
+        fn member(&self, ctx: QueryCtx, addr: String) -> Result<MemberResp, Self::Error>;
+    }
+
+    #[contract]
+    impl Group for GroupContract {
+        type Error = Error;
+
+        #[msg(exec)]
+        fn update_admin(
+            &self,
+            _ctx: ExecCtx,
+            _admin: Option<String>,
+        ) -> Result<Response, Self::Error> {
+            todo!()
+        }
+
+        #[msg(exec)]
+        fn update_members(
+            &self,
+            _ctx: ExecCtx,
+            _remove: Vec<String>,
+            _add: Vec<Member>,
+        ) -> Result<Response, Self::Error> {
+            todo!()
+        }
+
+        #[msg(query)]
+        fn member(&self, _ctx: QueryCtx, _addr: String) -> Result<MemberResp, Self::Error> {
+            todo!()
+        }
+    }
 }
 
 pub struct GroupContract {
@@ -58,31 +95,6 @@ pub struct GroupContract {
 impl Default for GroupContract {
     fn default() -> Self {
         Self::new()
-    }
-}
-
-#[contract]
-impl Group for GroupContract {
-    type Error = Error;
-
-    #[msg(exec)]
-    fn update_admin(&self, _ctx: ExecCtx, _admin: Option<String>) -> Result<Response, Self::Error> {
-        todo!()
-    }
-
-    #[msg(exec)]
-    fn update_members(
-        &self,
-        _ctx: ExecCtx,
-        _remove: Vec<String>,
-        _add: Vec<Member>,
-    ) -> Result<Response, Self::Error> {
-        todo!()
-    }
-
-    #[msg(query)]
-    fn member(&self, _ctx: QueryCtx, _addr: String) -> Result<MemberResp, Self::Error> {
-        todo!()
     }
 }
 


### PR DESCRIPTION
This fixes how MT utils are generated (not only for test passes) and makes names a bit more user-friendly.