### PR TITLE
entry_points no longer generate CONST Contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## \[0.4.2] - 2023-05-24
+## \[0.4.2\] - 2023-05-24
 
 - Added support of `#[msg(reply)]` defining handler for reply messages,
   currently only in the form of
@@ -13,6 +13,8 @@ and this project adheres to
   handler
 - Added generation of reply implementation forwarding to `#[msg(reply)]`
   handler in multitest helpers
+- Removed requirement for `const fn new()` method for `contract` macro call.
+  `fn new()` method is still required.
 
 ## \[0.4.1\] - 2023-05-23
 

--- a/sylvia-derive/src/message.rs
+++ b/sylvia-derive/src/message.rs
@@ -1067,7 +1067,7 @@ impl EntryPoints {
                         env: #sylvia ::cw_std::Env,
                         msg: #sylvia ::cw_std::Reply,
                     ) -> Result<#sylvia ::cw_std::Response, #error> {
-                        CONTRACT. #reply((deps, env).into(), msg).map_err(Into::into)
+                        #name ::new(). #reply((deps, env).into(), msg).map_err(Into::into)
                     }
                 },
                 None => quote! {},
@@ -1076,7 +1076,6 @@ impl EntryPoints {
             quote! {
                 pub mod entry_points {
                     use super::*;
-                    const CONTRACT: #name = #name ::new();
 
                     #[#sylvia ::cw_std::entry_point]
                     pub fn instantiate(
@@ -1085,7 +1084,7 @@ impl EntryPoints {
                         info: #sylvia ::cw_std::MessageInfo,
                         msg: InstantiateMsg,
                     ) -> Result<#sylvia ::cw_std::Response, #error> {
-                        msg.dispatch(&CONTRACT, (deps, env, info)).map_err(Into::into)
+                        msg.dispatch(&#name ::new() , (deps, env, info)).map_err(Into::into)
                     }
 
                     #[#sylvia ::cw_std::entry_point]
@@ -1095,12 +1094,12 @@ impl EntryPoints {
                         info: #sylvia ::cw_std::MessageInfo,
                         msg: ContractExecMsg,
                     ) -> Result<#sylvia ::cw_std::Response, #error> {
-                        msg.dispatch(&CONTRACT, (deps, env, info)).map_err(Into::into)
+                        msg.dispatch(&#name ::new(), (deps, env, info)).map_err(Into::into)
                     }
 
                     #[#sylvia ::cw_std::entry_point]
                     pub fn query(deps: #sylvia ::cw_std::Deps, env: #sylvia ::cw_std::Env, msg: ContractQueryMsg) -> Result<#sylvia ::cw_std::Binary, #error> {
-                        msg.dispatch(&CONTRACT, (deps, env)).map_err(Into::into)
+                        msg.dispatch(&#name ::new(), (deps, env)).map_err(Into::into)
                     }
 
                     #reply

--- a/sylvia/tests/messages_generation.rs
+++ b/sylvia/tests/messages_generation.rs
@@ -38,7 +38,7 @@ pub struct Contract {}
 #[contract(module=contract)]
 impl Contract {
     #[allow(clippy::new_without_default)]
-    pub const fn new() -> Self {
+    pub fn new() -> Self {
         Self {}
     }
 


### PR DESCRIPTION
This removes requirement of creating `const fn new` method for all contracts