### PR TITLE
fix!: `Remote` type implements all relevant traits so it can be stored in `#[cw_serde]` types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,9 +124,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-schema"
-version = "1.2.1"
+version = "1.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9118e36843df6648fd0a626c46438f87038f296ec750cef3832cafc483c483f9"
+checksum = "230e5d1cefae5331db8934763c81b9c871db6a2cd899056a5694fa71d292c815"
 dependencies = [
  "cosmwasm-schema-derive",
  "schemars",
@@ -137,9 +137,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-schema-derive"
-version = "1.2.1"
+version = "1.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78d6fc9854ac14e46cb69b0f396547893f93d2847aef975950ebbe73342324f3"
+checksum = "43dadf7c23406cb28079d69e6cb922c9c29b9157b0fe887e3b79c783b7d4bcb8"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/sylvia-derive/src/remote.rs
+++ b/sylvia-derive/src/remote.rs
@@ -48,7 +48,7 @@ impl Remote {
         });
 
         quote! {
-            #[derive(#sylvia ::serde::Serialize, #sylvia ::serde::Deserialize)]
+            #[derive(#sylvia ::serde::Serialize, #sylvia ::serde::Deserialize, Clone, Debug, PartialEq, #sylvia ::schemars::JsonSchema)]
             pub struct Remote<'a>(std::borrow::Cow<'a, #sylvia ::cw_std::Addr>);
 
             impl Remote<'static> {

--- a/sylvia/tests/remote.rs
+++ b/sylvia/tests/remote.rs
@@ -1,3 +1,4 @@
+use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{Response, StdResult};
 use sylvia::contract;
 use sylvia::types::InstantiateCtx;
@@ -30,6 +31,13 @@ impl SomeContract {
     pub fn instantiate(&self, _ctx: InstantiateCtx) -> StdResult<Response> {
         Ok(Response::new())
     }
+}
+
+// Making sure `Remote` can be stored in `#[cw_serde]` types
+#[cw_serde]
+#[allow(dead_code)]
+struct CustomStorage {
+    remote: crate::Remote<'static>,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Closes #181 

BREAKING CHANGE: new traits are generated on the `Remote` type: `Clone`, `Debug`, `PartialEq`, `schemars::JsonSchema`. If any traits with functions of the same signature as one of added traits are implemented manually on the `Remote` type (eg.: `fn clone()`), it might break compilation. It is very unlikely case, but technically possible.