### PR TITLE
Support generic interface on contract

### DIFF
--- a/sylvia-derive/src/check_generics.rs
+++ b/sylvia-derive/src/check_generics.rs
@@ -1,26 +1,57 @@
 use syn::visit::Visit;
-use syn::GenericParam;
+use syn::{parse_quote, GenericArgument, GenericParam, Type};
 
-#[derive(Debug)]
-pub struct CheckGenerics<'g> {
-    generics: &'g [&'g GenericParam],
-    used: Vec<&'g GenericParam>,
+pub trait GetPath {
+    fn get_path(&self) -> Option<syn::Path>;
 }
 
-impl<'g> CheckGenerics<'g> {
-    pub fn new(generics: &'g [&'g GenericParam]) -> Self {
+impl GetPath for GenericParam {
+    fn get_path(&self) -> Option<syn::Path> {
+        match self {
+            GenericParam::Type(ty) => {
+                let ident = &ty.ident;
+                Some(parse_quote! { #ident })
+            }
+            _ => None,
+        }
+    }
+}
+
+impl GetPath for GenericArgument {
+    fn get_path(&self) -> Option<syn::Path> {
+        match self {
+            GenericArgument::Type(Type::Path(path)) => {
+                let path = &path.path;
+                Some(parse_quote! { #path })
+            }
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct CheckGenerics<'g, Generic> {
+    generics: &'g [&'g Generic],
+    used: Vec<&'g Generic>,
+}
+
+impl<'g, Generic> CheckGenerics<'g, Generic>
+where
+    Generic: GetPath + PartialEq,
+{
+    pub fn new(generics: &'g [&'g Generic]) -> Self {
         Self {
             generics,
             used: vec![],
         }
     }
 
-    pub fn used(self) -> Vec<&'g GenericParam> {
+    pub fn used(self) -> Vec<&'g Generic> {
         self.used
     }
 
     /// Returns split between used and unused generics
-    pub fn used_unused(self) -> (Vec<&'g GenericParam>, Vec<&'g GenericParam>) {
+    pub fn used_unused(self) -> (Vec<&'g Generic>, Vec<&'g Generic>) {
         let unused = self
             .generics
             .iter()
@@ -32,17 +63,18 @@ impl<'g> CheckGenerics<'g> {
     }
 }
 
-impl<'ast, 'g> Visit<'ast> for CheckGenerics<'g> {
+impl<'ast, 'g, Generic> Visit<'ast> for CheckGenerics<'g, Generic>
+where
+    Generic: GetPath + PartialEq,
+{
     fn visit_path(&mut self, p: &'ast syn::Path) {
-        if let Some(p) = p.get_ident() {
-            if let Some(gen) = self
-                .generics
-                .iter()
-                .find(|gen| matches!(gen, GenericParam::Type(ty) if ty.ident == *p))
-            {
-                if !self.used.contains(gen) {
-                    self.used.push(gen);
-                }
+        if let Some(gen) = self
+            .generics
+            .iter()
+            .find(|gen| gen.get_path().as_ref() == Some(p))
+        {
+            if !self.used.contains(gen) {
+                self.used.push(gen);
             }
         }
 

--- a/sylvia-derive/src/parser.rs
+++ b/sylvia-derive/src/parser.rs
@@ -152,6 +152,14 @@ impl MsgType {
             MsgType::Sudo => todo!(),
         }
     }
+
+    pub fn as_accessor_name(&self) -> Option<Type> {
+        match self {
+            MsgType::Exec => Some(parse_quote! { Exec }),
+            MsgType::Query => Some(parse_quote! { Query }),
+            _ => None,
+        }
+    }
 }
 
 impl PartialEq<MsgType> for MsgAttr {
@@ -238,34 +246,8 @@ pub struct Customs {
 #[derive(Debug)]
 pub struct ContractMessageAttr {
     pub module: Path,
-    pub exec_generic_params: Vec<Path>,
-    pub query_generic_params: Vec<Path>,
     pub variant: Ident,
     pub customs: Customs,
-}
-
-#[cfg(not(tarpaulin_include))]
-// False negative. Called in function below
-fn parse_generics(content: &ParseBuffer) -> Result<Vec<Path>> {
-    let _: Token![<] = content.parse()?;
-    let mut params = vec![];
-
-    loop {
-        let param: Path = content.parse()?;
-        params.push(param);
-
-        let generics_close: Option<Token![>]> = content.parse()?;
-        if generics_close.is_some() {
-            break;
-        }
-
-        let comma: Option<Token![,]> = content.parse()?;
-        if comma.is_none() {
-            return Err(Error::new(content.span(), "Expected comma or `>`"));
-        }
-    }
-
-    Ok(params)
 }
 
 fn interface_has_custom(content: ParseStream) -> Result<Customs> {
@@ -312,31 +294,6 @@ impl Parse for ContractMessageAttr {
 
         let module = content.parse()?;
 
-        let generics_open: Option<Token![:]> = content.parse()?;
-        let mut exec_generic_params = vec![];
-        let mut query_generic_params = vec![];
-
-        if generics_open.is_some() {
-            loop {
-                let ty: Ident = content.parse()?;
-                let params = if ty == "exec" {
-                    &mut exec_generic_params
-                } else if ty == "query" {
-                    &mut query_generic_params
-                } else {
-                    return Err(Error::new(ty.span(), "Invalid message type"));
-                };
-
-                *params = parse_generics(&content)?;
-
-                if content.peek(Token![as]) {
-                    break;
-                }
-
-                let _: Token![,] = content.parse()?;
-            }
-        }
-
         let _: Token![as] = content.parse()?;
         let variant = content.parse()?;
 
@@ -351,8 +308,6 @@ impl Parse for ContractMessageAttr {
 
         Ok(Self {
             module,
-            exec_generic_params,
-            query_generic_params,
             variant,
             customs,
         })

--- a/sylvia/tests/generics.rs
+++ b/sylvia/tests/generics.rs
@@ -29,6 +29,58 @@ pub mod cw1 {
     }
 }
 
+pub mod cw1_contract {
+    use cosmwasm_std::{Response, StdResult};
+    use sylvia::types::InstantiateCtx;
+    use sylvia_derive::contract;
+
+    pub struct Cw1Contract;
+
+    #[contract]
+    impl Cw1Contract {
+        pub const fn new() -> Self {
+            Self
+        }
+
+        #[msg(instantiate)]
+        pub fn instantiate(&self, _ctx: InstantiateCtx) -> StdResult<Response> {
+            Ok(Response::new())
+        }
+    }
+}
+
+pub mod impl_cw1 {
+    use cosmwasm_std::{CosmosMsg, Response, StdError};
+    use sylvia::types::{ExecCtx, QueryCtx};
+    use sylvia_derive::contract;
+
+    use crate::{cw1::Cw1, cw1_contract::Cw1Contract, ExternalMsg};
+
+    #[contract(module = crate::cw1_contract)]
+    #[messages(crate::cw1 as Cw1)]
+    impl Cw1<ExternalMsg, crate::ExternalMsg, crate::ExternalQuery> for Cw1Contract {
+        type Error = StdError;
+
+        #[msg(exec)]
+        fn execute(
+            &self,
+            _ctx: ExecCtx,
+            _msgs: Vec<CosmosMsg<ExternalMsg>>,
+        ) -> Result<Response<ExternalMsg>, Self::Error> {
+            Ok(Response::new())
+        }
+
+        #[msg(query)]
+        fn some_query(
+            &self,
+            _ctx: QueryCtx,
+            _param: crate::ExternalMsg,
+        ) -> Result<crate::ExternalQuery, Self::Error> {
+            Ok(crate::ExternalQuery {})
+        }
+    }
+}
+
 #[cw_serde]
 pub struct ExternalMsg;
 impl cosmwasm_std::CustomMsg for ExternalMsg {}
@@ -37,7 +89,7 @@ impl cosmwasm_std::CustomMsg for ExternalMsg {}
 pub struct ExternalQuery;
 impl cosmwasm_std::CustomQuery for ExternalQuery {}
 
-#[cfg(test)]
+#[cfg(all(test, feature = "mt"))]
 mod tests {
     use cosmwasm_std::{testing::mock_dependencies, Addr, CosmosMsg, Empty, QuerierWrapper};
 


### PR DESCRIPTION
Part 1/2 of #226

This change lacks `#[messages()]` attribute on main `#[contract]` call as it is already a big PR