### PR TITLE
Contract api

### DIFF
--- a/examples/interfaces/custom-and-generic/src/lib.rs
+++ b/examples/interfaces/custom-and-generic/src/lib.rs
@@ -34,7 +34,7 @@ where
 mod tests {
     use cosmwasm_std::testing::mock_dependencies;
     use cosmwasm_std::{Addr, CosmosMsg, Empty, QuerierWrapper};
-    use sylvia::types::{InterfaceMessages, SvCustomMsg};
+    use sylvia::types::{InterfaceApi, SvCustomMsg};
 
     use crate::sv::Querier;
 
@@ -58,11 +58,11 @@ mod tests {
 
         // Construct messages with Interface extension
         let _ =
-            <super::sv::InterfaceTypes<SvCustomMsg, _, SvCustomMsg> as InterfaceMessages>::Query::custom_generic_query(
+            <super::sv::Api<SvCustomMsg, _, SvCustomMsg> as InterfaceApi>::Query::custom_generic_query(
                 SvCustomMsg {},
             );
         let _=
-            <super::sv::InterfaceTypes<_, SvCustomMsg, cosmwasm_std::Empty> as InterfaceMessages>::Exec::custom_generic_execute(
+            <super::sv::Api<_, SvCustomMsg, cosmwasm_std::Empty> as InterfaceApi>::Exec::custom_generic_execute(
             vec![ CosmosMsg::Custom(SvCustomMsg{}),
             ]);
     }

--- a/examples/interfaces/generic/src/lib.rs
+++ b/examples/interfaces/generic/src/lib.rs
@@ -27,7 +27,7 @@ where
 #[cfg(test)]
 mod tests {
     use cosmwasm_std::{testing::mock_dependencies, Addr, CosmosMsg, Empty, QuerierWrapper};
-    use sylvia::types::{InterfaceMessages, SvCustomMsg};
+    use sylvia::types::{InterfaceApi, SvCustomMsg};
 
     use crate::sv::Querier;
 
@@ -49,12 +49,11 @@ mod tests {
         let _: Result<SvCustomMsg, _> = querier.generic_query(SvCustomMsg {});
 
         // Construct messages with Interface extension
-        let _ =
-            <super::sv::InterfaceTypes<SvCustomMsg, _, SvCustomMsg> as InterfaceMessages>::Query::generic_query(
-                SvCustomMsg {},
-            );
+        let _ = <super::sv::Api<SvCustomMsg, _, SvCustomMsg> as InterfaceApi>::Query::generic_query(
+            SvCustomMsg {},
+        );
         let _=
-            <super::sv::InterfaceTypes<_, SvCustomMsg, cosmwasm_std::Empty> as InterfaceMessages>::Exec::generic_exec(vec![
+            <super::sv::Api<_, SvCustomMsg, cosmwasm_std::Empty> as InterfaceApi>::Exec::generic_exec(vec![
                 CosmosMsg::Custom(SvCustomMsg{}),
             ]);
     }

--- a/sylvia-derive/src/interfaces.rs
+++ b/sylvia-derive/src/interfaces.rs
@@ -95,7 +95,7 @@ impl Interfaces {
                 };
 
                 let interface_enum =
-                    quote! { <#module ::sv::InterfaceTypes #generics as #sylvia ::types::InterfaceMessages> };
+                    quote! { <#module ::sv::Api #generics as #sylvia ::types::InterfaceApi> };
                 if msg_ty == &MsgType::Query {
                     quote! { #variant ( #interface_enum :: Query) }
                 } else {
@@ -161,7 +161,7 @@ impl Interfaces {
 
                 let type_name = msg_ty.as_accessor_name();
                 quote! {
-                    <#module ::sv::InterfaceTypes #generics as #sylvia ::types::InterfaceMessages> :: #type_name :: response_schemas_impl()
+                    <#module ::sv::Api #generics as #sylvia ::types::InterfaceApi> :: #type_name :: response_schemas_impl()
                 }
             })
             .collect()

--- a/sylvia-derive/src/multitest.rs
+++ b/sylvia-derive/src/multitest.rs
@@ -323,7 +323,8 @@ where
         };
 
         let bracketed_generics = emit_bracketed_generics(generics);
-        let interface_enum = quote! { < #module sv::InterfaceTypes #bracketed_generics as #sylvia ::types::InterfaceMessages> };
+        let interface_enum =
+            quote! { < #module sv::Api #bracketed_generics as #sylvia ::types::InterfaceApi> };
 
         let exec_methods = exec_variants.emit_interface_multitest_proxy_methods(
             &custom_msg,

--- a/sylvia-derive/src/remote.rs
+++ b/sylvia-derive/src/remote.rs
@@ -33,13 +33,11 @@ impl<'a> Remote<'a> {
             #[derive(#sylvia ::serde::Serialize, #sylvia ::serde::Deserialize, Clone, Debug, PartialEq, #sylvia ::schemars::JsonSchema)]
             pub struct Remote<'a>(std::borrow::Cow<'a, #sylvia ::cw_std::Addr>);
 
-            impl Remote<'static> {
+            impl<'a> Remote<'a> {
                 pub fn new(addr: #sylvia ::cw_std::Addr) -> Self {
                     Self(std::borrow::Cow::Owned(addr))
                 }
-            }
 
-            impl<'a> Remote<'a> {
                 pub fn borrowed(addr: &'a #sylvia ::cw_std::Addr) -> Self {
                     Self(std::borrow::Cow::Borrowed(addr))
                 }

--- a/sylvia/src/types.rs
+++ b/sylvia/src/types.rs
@@ -105,7 +105,18 @@ pub struct SvCustomMsg;
 
 impl cosmwasm_std::CustomMsg for SvCustomMsg {}
 
-pub trait InterfaceMessages {
+pub trait InterfaceApi {
     type Exec;
     type Query;
+}
+
+pub trait ContractApi {
+    type Instantiate;
+    type Query;
+    type Exec;
+    type ContractQuery;
+    type ContractExec;
+    type Migrate;
+    type Querier<'querier>;
+    type Remote<'remote>;
 }

--- a/sylvia/tests/api.rs
+++ b/sylvia/tests/api.rs
@@ -1,0 +1,127 @@
+use cosmwasm_std::{Response, StdResult};
+use std::marker::PhantomData;
+
+use sylvia::types::{CustomMsg, ExecCtx, InstantiateCtx, MigrateCtx, QueryCtx};
+use sylvia_derive::contract;
+
+pub struct SomeContract<Instantiate, Query, Exec, Migrate, Ret> {
+    _phantom: PhantomData<(Instantiate, Query, Exec, Migrate, Ret)>,
+}
+
+#[contract]
+impl<Instantiate, Query, Exec, Migrate, Ret> SomeContract<Instantiate, Query, Exec, Migrate, Ret>
+where
+    Instantiate: CustomMsg + 'static,
+    Query: CustomMsg + 'static,
+    Exec: CustomMsg + 'static,
+    Migrate: CustomMsg + 'static,
+    Ret: CustomMsg + 'static,
+{
+    pub const fn new() -> Self {
+        Self {
+            _phantom: PhantomData,
+        }
+    }
+
+    #[msg(instantiate)]
+    pub fn instantiate(&self, _ctx: InstantiateCtx, _param: Instantiate) -> StdResult<Response> {
+        Ok(Response::new())
+    }
+
+    #[msg(exec)]
+    pub fn exec(&self, _ctx: ExecCtx, _param: Exec) -> StdResult<Response> {
+        Ok(Response::new())
+    }
+
+    #[msg(query)]
+    pub fn query(&self, _ctx: QueryCtx, _param: Query) -> StdResult<Response> {
+        Ok(Response::new())
+    }
+
+    #[msg(migrate)]
+    pub fn migrate(&self, _ctx: MigrateCtx, _param: Migrate) -> StdResult<Response> {
+        Ok(Response::new())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::SomeContract;
+    use cosmwasm_std::{testing::mock_dependencies, Addr, QuerierWrapper};
+    use sylvia::types::{ContractApi, SvCustomMsg};
+
+    #[test]
+    fn api() {
+        let owner = Addr::unchecked("owner");
+
+        let _: crate::sv::InstantiateMsg<SvCustomMsg> = <SomeContract<
+            SvCustomMsg,
+            SvCustomMsg,
+            SvCustomMsg,
+            SvCustomMsg,
+            SvCustomMsg,
+        > as ContractApi>::Instantiate::new(
+            SvCustomMsg
+        );
+
+        let exec: crate::sv::ExecMsg<SvCustomMsg> = <SomeContract<
+            SvCustomMsg,
+            SvCustomMsg,
+            SvCustomMsg,
+            SvCustomMsg,
+            SvCustomMsg,
+        > as ContractApi>::Exec::exec(
+            SvCustomMsg
+        );
+
+        let query: crate::sv::QueryMsg<SvCustomMsg> = <SomeContract<
+            SvCustomMsg,
+            SvCustomMsg,
+            SvCustomMsg,
+            SvCustomMsg,
+            SvCustomMsg,
+        > as ContractApi>::Query::query(
+            SvCustomMsg
+        );
+
+        let _: crate::sv::ContractExecMsg<SvCustomMsg> = <SomeContract<
+            SvCustomMsg,
+            SvCustomMsg,
+            SvCustomMsg,
+            SvCustomMsg,
+            SvCustomMsg,
+        > as ContractApi>::ContractExec::SomeContract(
+            exec
+        );
+
+        let _: crate::sv::ContractQueryMsg<SvCustomMsg> = <SomeContract<
+            SvCustomMsg,
+            SvCustomMsg,
+            SvCustomMsg,
+            SvCustomMsg,
+            SvCustomMsg,
+        > as ContractApi>::ContractQuery::SomeContract(
+            query
+        );
+
+        let _: crate::sv::Remote<'_> = <SomeContract<
+            SvCustomMsg,
+            SvCustomMsg,
+            SvCustomMsg,
+            SvCustomMsg,
+            SvCustomMsg,
+        > as ContractApi>::Remote::new(owner.clone());
+
+        let deps = mock_dependencies();
+        let querier_wrapper: QuerierWrapper = QuerierWrapper::new(&deps.querier);
+        let _: crate::sv::BoundQuerier<'_, cosmwasm_std::Empty> = <SomeContract<
+            SvCustomMsg,
+            SvCustomMsg,
+            SvCustomMsg,
+            SvCustomMsg,
+            SvCustomMsg,
+        > as ContractApi>::Querier::borrowed(
+            &owner, &querier_wrapper
+        );
+    }
+}


### PR DESCRIPTION
Impl Extension trait on Contract. This change is required to generate `entry_point`s without requiring user to specify which generics are for which messages.

Unfortunately rust compiler requires fully-qualified path and in current state it's not the most user friendly Api so the primary use case is code generation.

#86 