### PR TITLE
fix: Expect `,` in `:custom(msg, query)`

### DIFF
--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -237,6 +237,7 @@ dependencies = [
  "cosmwasm-std",
  "cw-multi-test",
  "cw-storage-plus",
+ "cw1",
  "serde",
  "sylvia",
 ]

--- a/examples/contracts/custom/Cargo.toml
+++ b/examples/contracts/custom/Cargo.toml
@@ -13,14 +13,17 @@ crate-type = ["cdylib", "rlib"]
 
 [features]
 library = []
-mt = ["library"]
+mt = ["library", "anyhow", "cw-multi-test"]
 
 [dependencies]
+cw1 = { path = "../../interfaces/cw1" }
 cosmwasm-schema = "1.2"
 cosmwasm-std = { version = "1.3", features = ["staking"] }
 cw-storage-plus = "1.0"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 sylvia = { path = "../../../sylvia" }
+cw-multi-test = { version = "0.16", optional = true }
+anyhow = { version = "1.0", optional = true }
 
 [dev-dependencies]
 anyhow = "1.0"

--- a/examples/contracts/custom/src/contract.rs
+++ b/examples/contracts/custom/src/contract.rs
@@ -1,13 +1,17 @@
 use cosmwasm_std::{CosmosMsg, QueryRequest, Response, StdResult};
 use sylvia::types::{ExecCtx, InstantiateCtx, QueryCtx};
-use sylvia::{contract, entry_points, schemars};
+use sylvia::{contract, schemars};
+
+#[cfg(not(feature = "library"))]
+use sylvia::entry_points;
 
 use crate::messages::{CountResponse, CounterMsg, CounterQuery};
 
 pub struct CustomContract;
 
-#[cfg_attr(not(feature = "mt"), entry_points)]
+#[cfg_attr(not(feature = "library"), entry_points)]
 #[contract]
+#[messages(cw1 as Cw1: custom(msg, query))]
 #[sv::custom(query=CounterQuery, msg=CounterMsg)]
 impl CustomContract {
     pub const fn new() -> Self {

--- a/examples/contracts/custom/src/cw1.rs
+++ b/examples/contracts/custom/src/cw1.rs
@@ -1,0 +1,29 @@
+use crate::messages::CounterMsg;
+use cosmwasm_std::{CosmosMsg, Response, StdError, StdResult};
+use cw1::{CanExecuteResp, Cw1};
+use sylvia::contract;
+use sylvia::types::{ExecCtx, QueryCtx};
+
+use crate::contract::CustomContract;
+
+#[contract(module=crate::contract)]
+#[messages(cw1 as Cw1)]
+#[sv::custom(query=CounterQuery, msg=CounterMsg)]
+impl Cw1 for CustomContract {
+    type Error = StdError;
+
+    #[msg(exec)]
+    fn execute(&self, _ctx: ExecCtx, _msgs: Vec<CosmosMsg>) -> StdResult<Response> {
+        Ok(Response::new())
+    }
+
+    #[msg(query)]
+    fn can_execute(
+        &self,
+        _ctx: QueryCtx,
+        _sender: String,
+        _msg: CosmosMsg,
+    ) -> StdResult<CanExecuteResp> {
+        Ok(CanExecuteResp::default())
+    }
+}

--- a/examples/contracts/custom/src/lib.rs
+++ b/examples/contracts/custom/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod contract;
+pub mod cw1;
 pub mod messages;
 #[cfg(any(test, feature = "mt"))]
 pub mod multitest;

--- a/examples/contracts/custom/src/multitest.rs
+++ b/examples/contracts/custom/src/multitest.rs
@@ -1,2 +1,3 @@
-mod custom_module;
+pub mod custom_module;
+#[cfg(test)]
 mod tests;

--- a/examples/contracts/custom/src/multitest/custom_module.rs
+++ b/examples/contracts/custom/src/multitest/custom_module.rs
@@ -1,35 +1,28 @@
 use cosmwasm_schema::schemars::JsonSchema;
-use cosmwasm_std::testing::{MockApi, MockStorage};
 use cosmwasm_std::{
     to_binary, Addr, Api, Binary, BlockInfo, CustomQuery, Empty, Querier, StdError, StdResult,
     Storage,
 };
-use cw_multi_test::{AppResponse, BankKeeper, CosmosRouter, Module, WasmKeeper};
+use cw_multi_test::{AppResponse, CosmosRouter, Module};
 use cw_storage_plus::Item;
 use serde::de::DeserializeOwned;
 use std::fmt::Debug;
 
 use crate::messages::{CountResponse, CounterMsg, CounterQuery};
 
-pub type CustomApp = cw_multi_test::App<
-    BankKeeper,
-    MockApi,
-    MockStorage,
-    CustomModule,
-    WasmKeeper<CounterMsg, CounterQuery>,
->;
-
 pub struct CustomModule {
     pub counter: Item<'static, u64>,
 }
 
-impl CustomModule {
-    pub fn new() -> Self {
+impl Default for CustomModule {
+    fn default() -> Self {
         Self {
             counter: Item::new("counter"),
         }
     }
+}
 
+impl CustomModule {
     pub fn save_counter(&self, storage: &mut dyn Storage, value: u64) -> StdResult<()> {
         self.counter.save(storage, &value)
     }

--- a/examples/contracts/custom/src/multitest/tests.rs
+++ b/examples/contracts/custom/src/multitest/tests.rs
@@ -2,19 +2,19 @@ use sylvia::multitest::App;
 
 use crate::contract::multitest_utils::CodeId;
 
-use super::custom_module::{CustomApp, CustomModule};
+use super::custom_module::CustomModule;
 
 #[test]
 fn test_custom() {
     let owner = "owner";
 
     let mt_app = cw_multi_test::BasicAppBuilder::new_custom()
-        .with_custom(CustomModule::new())
+        .with_custom(CustomModule::default())
         .build(|router, _, storage| {
             router.custom.save_counter(storage, 0).unwrap();
         });
 
-    let app = App::<CustomApp>::new(mt_app);
+    let app = App::new(mt_app);
 
     let code_id = CodeId::store_code(&app);
 

--- a/sylvia-derive/src/parser.rs
+++ b/sylvia-derive/src/parser.rs
@@ -299,6 +299,10 @@ fn interface_has_custom(content: ParseStream) -> Result<Customs> {
                 ))
             }
         }
+        if !custom_content.peek(Token![,]) {
+            break;
+        }
+        let _: Token![,] = custom_content.parse()?;
     }
     Ok(customs)
 }


### PR DESCRIPTION
This check was missed in tests. Found it while updating the sylvia book.