### PR TITLE
feat: Remove custom in impl trait

### DIFF
--- a/README.md
+++ b/README.md
@@ -907,7 +907,6 @@ pub trait SomeInterface {
 }
 
 #[contract(module=super)]
-#[sv::custom(msg=MyMsg, query=MyQuery)]
 impl SomeInterface for crate::MyContract {
 }
 ```
@@ -926,7 +925,6 @@ pub trait AssociatedInterface {
 }
 
 #[contract(module=super)]
-#[sv::custom(msg=MyMsg)]
 impl AssociatedInterface for crate::MyContract {
     type Error = StdError;
     type ExecC = MyMsg;
@@ -1040,7 +1038,6 @@ We can either use some concrete types here or forward the generics defined on co
 ```rust
 #[contract(module = crate::contract)]
 #[sv::messages(generic as Generic)]
-#[sv::custom(msg=SvCustomMsg)]
 impl<InstantiateParam, ExecParam, FieldType>
     Generic
     for crate::contract::GenericContract<

--- a/examples/contracts/custom/Cargo.toml
+++ b/examples/contracts/custom/Cargo.toml
@@ -15,6 +15,7 @@ crate-type = ["cdylib", "rlib"]
 library = []
 mt = ["library", "anyhow", "cw-multi-test"]
 
+
 [dependencies]
 cw1 = { path = "../../interfaces/cw1" }
 cosmwasm-schema = { workspace = true }

--- a/examples/contracts/custom/src/cw1.rs
+++ b/examples/contracts/custom/src/cw1.rs
@@ -1,4 +1,3 @@
-use crate::messages::CounterMsg;
 use cosmwasm_std::{CosmosMsg, Response, StdError, StdResult};
 use cw1::{CanExecuteResp, Cw1};
 use sylvia::contract;
@@ -8,7 +7,6 @@ use crate::contract::CustomContract;
 
 #[contract(module=crate::contract)]
 #[sv::messages(cw1 as Cw1)]
-#[sv::custom(query=CounterQuery, msg=CounterMsg)]
 impl Cw1 for CustomContract {
     type Error = StdError;
 

--- a/examples/contracts/custom/src/multitest/tests.rs
+++ b/examples/contracts/custom/src/multitest/tests.rs
@@ -4,6 +4,10 @@ use crate::contract::sv::multitest_utils::CodeId;
 
 use super::custom_module::CustomModule;
 
+use crate::cw1::sv::test_utils::Cw1;
+
+use cosmwasm_std::CosmosMsg;
+
 #[test]
 fn test_custom() {
     let owner = "owner";
@@ -21,6 +25,11 @@ fn test_custom() {
     let contract = code_id.instantiate().call(owner).unwrap();
 
     contract.send_custom().call(owner).unwrap();
+
+    contract
+        .can_execute("".to_string(), CosmosMsg::Custom(cosmwasm_std::Empty {}))
+        .unwrap();
+    contract.execute(vec![]).call(owner).unwrap();
 
     let count = contract.query_custom().unwrap().count;
     assert_eq!(count, 1);

--- a/examples/contracts/generic_contract/src/custom_and_generic.rs
+++ b/examples/contracts/generic_contract/src/custom_and_generic.rs
@@ -5,7 +5,6 @@ use sylvia::types::{ExecCtx, QueryCtx, SudoCtx, SvCustomMsg, SvCustomQuery};
 
 #[contract(module = crate::contract)]
 #[sv::messages(custom_and_generic as CustomAndGeneric)]
-#[sv::custom(msg=SvCustomMsg, query=SvCustomQuery)]
 impl<
         InstantiateT,
         Exec1T,

--- a/examples/contracts/generic_contract/src/cw1.rs
+++ b/examples/contracts/generic_contract/src/cw1.rs
@@ -5,7 +5,6 @@ use sylvia::types::{ExecCtx, QueryCtx};
 
 #[contract(module = crate::contract)]
 #[sv::messages(cw1 as Cw1)]
-#[sv::custom(msg=sylvia::types::SvCustomMsg, query=sylvia::types::SvCustomQuery)]
 impl<
         InstantiateT,
         Exec1T,

--- a/examples/contracts/generic_contract/src/generic.rs
+++ b/examples/contracts/generic_contract/src/generic.rs
@@ -6,7 +6,6 @@ use sylvia::types::{CustomMsg, ExecCtx, QueryCtx, SudoCtx, SvCustomMsg};
 
 #[contract(module = crate::contract)]
 #[sv::messages(generic as Generic)]
-#[sv::custom(msg=SvCustomMsg, query=SvCustomQuery)]
 impl<
         InstantiateT,
         Exec1T,

--- a/examples/contracts/generic_iface_on_contract/src/custom_and_generic.rs
+++ b/examples/contracts/generic_iface_on_contract/src/custom_and_generic.rs
@@ -5,7 +5,6 @@ use sylvia::types::{ExecCtx, QueryCtx, SudoCtx, SvCustomMsg, SvCustomQuery};
 
 #[contract(module = crate::contract)]
 #[sv::messages(custom_and_generic as CustomAndGeneric)]
-#[sv::custom(msg=sylvia::types::SvCustomMsg, query=SvCustomQuery)]
 impl CustomAndGeneric for crate::contract::NonGenericContract {
     type Error = StdError;
     type Exec1T = SvCustomMsg;

--- a/examples/contracts/generic_iface_on_contract/src/cw1.rs
+++ b/examples/contracts/generic_iface_on_contract/src/cw1.rs
@@ -5,7 +5,6 @@ use sylvia::types::{ExecCtx, QueryCtx};
 
 #[contract(module = crate::contract)]
 #[sv::messages(cw1 as Cw1)]
-#[sv::custom(msg=sylvia::types::SvCustomMsg)]
 impl Cw1 for crate::contract::NonGenericContract {
     type Error = StdError;
 

--- a/examples/contracts/generic_iface_on_contract/src/generic.rs
+++ b/examples/contracts/generic_iface_on_contract/src/generic.rs
@@ -5,7 +5,6 @@ use sylvia::types::{ExecCtx, QueryCtx, SudoCtx, SvCustomMsg};
 
 #[contract(module = crate::contract)]
 #[sv::messages(generic as Generic)]
-#[sv::custom(msg = SvCustomMsg)]
 impl Generic for crate::contract::NonGenericContract {
     type Error = StdError;
     type Exec1T = SvCustomMsg;

--- a/examples/contracts/generics_forwarded/src/cw1.rs
+++ b/examples/contracts/generics_forwarded/src/cw1.rs
@@ -4,11 +4,10 @@ use cw1::{CanExecuteResp, Cw1};
 use serde::de::DeserializeOwned;
 use serde::Deserialize;
 use sylvia::contract;
-use sylvia::types::{CustomQuery, ExecCtx, QueryCtx, SvCustomMsg};
+use sylvia::types::{CustomQuery, ExecCtx, QueryCtx};
 
 #[contract(module = crate::contract)]
 #[sv::messages(cw1 as Cw1)]
-#[sv::custom(msg=SvCustomMsg, query=SvCustomQuery)]
 impl<
         InstantiateT,
         Exec1T,

--- a/examples/contracts/generics_forwarded/src/generic.rs
+++ b/examples/contracts/generics_forwarded/src/generic.rs
@@ -6,7 +6,6 @@ use sylvia::types::{CustomMsg, CustomQuery, ExecCtx, QueryCtx, SudoCtx, SvCustom
 
 #[contract(module = crate::contract)]
 #[sv::messages(generic as Generic)]
-#[sv::custom(msg=SvCustomMsg, query=SvCustomQuery)]
 impl<
         InstantiateT,
         Exec1T,

--- a/sylvia-derive/src/associated_types.rs
+++ b/sylvia-derive/src/associated_types.rs
@@ -134,13 +134,6 @@ impl<'a> ImplAssociatedTypes<'a> {
         self.filtered().copied().collect()
     }
 
-    pub fn custom_msg(&self) -> Option<&Type> {
-        self.0
-            .iter()
-            .find(|associated| associated.ident == EXEC_TYPE)
-            .map(|associated| &associated.ty)
-    }
-
     pub fn filtered(&self) -> impl Iterator<Item = &&ImplItemType> {
         self.0.iter().filter(|associated| {
             !RESERVED_TYPES

--- a/sylvia-derive/src/input.rs
+++ b/sylvia-derive/src/input.rs
@@ -132,22 +132,18 @@ pub struct ImplTraitInput<'a> {
     attributes: &'a ContractArgs,
     item: &'a ItemImpl,
     generics: Vec<&'a GenericParam>,
-    custom: Custom,
     interfaces: Interfaces,
 }
 
 impl<'a> ImplTraitInput<'a> {
     pub fn new(attributes: &'a ContractArgs, item: &'a ItemImpl) -> Self {
         let generics = item.generics.params.iter().collect();
-        let parsed_attrs = ParsedSylviaAttributes::new(item.attrs.iter());
-        let custom = parsed_attrs.custom_attr.unwrap_or_default();
         let interfaces = Interfaces::new(item);
 
         Self {
             attributes,
             item,
             generics,
-            custom,
             interfaces,
         }
     }
@@ -187,21 +183,11 @@ impl<'a> ImplTraitInput<'a> {
         }
 
         let Self {
-            item,
-            custom,
-            interfaces,
-            ..
+            item, interfaces, ..
         } = self;
         let generic_params = &self.generics;
 
-        ImplMtHelpers::new(
-            item,
-            generic_params,
-            custom,
-            interfaces,
-            &self.attributes.module,
-        )
-        .emit()
+        ImplMtHelpers::new(item, generic_params, interfaces, &self.attributes.module).emit()
     }
 }
 

--- a/sylvia/tests/custom_msg.rs
+++ b/sylvia/tests/custom_msg.rs
@@ -52,7 +52,6 @@ mod impl_some_interface {
 
     #[contract(module=crate)]
     #[sv::messages(crate::some_interface)]
-    #[sv::custom(msg=MyMsg)]
     impl SomeInterface for crate::MyContract {
         type Error = StdError;
 
@@ -105,7 +104,6 @@ mod impl_interface {
 
     #[contract(module=crate)]
     #[sv::messages(crate::interface)]
-    #[sv::custom(msg=MyMsg)]
     impl Interface for crate::MyContract {
         type Error = StdError;
         type ExecC = OtherMsg;
@@ -154,7 +152,6 @@ mod impl_other_interface {
 
     #[contract(module=crate)]
     #[sv::messages(crate::other_interface)]
-    #[sv::custom(msg=crate::MyMsg)]
     impl OtherInterface for crate::MyContract {
         type Error = StdError;
 
@@ -205,7 +202,6 @@ mod impl_associated_interface {
 
     #[contract(module=crate)]
     #[sv::messages(crate::associated_interface)]
-    #[sv::custom(msg=MyMsg)]
     impl AssociatedInterface for crate::MyContract {
         type Error = StdError;
         type ExecC = MyMsg;

--- a/sylvia/tests/custom_query.rs
+++ b/sylvia/tests/custom_query.rs
@@ -51,7 +51,6 @@ mod impl_interface {
 
     #[contract(module=crate)]
     #[sv::messages(crate::interface)]
-    #[sv::custom(query=MyQuery)]
     impl crate::interface::Interface for crate::MyContract {
         type Error = StdError;
         type QueryC = OtherQuery;
@@ -105,7 +104,6 @@ mod impl_some_interface {
 
     #[contract(module=crate)]
     #[sv::messages(crate::some_interface)]
-    #[sv::custom(query=MyQuery)]
     impl super::some_interface::SomeInterface for crate::MyContract {
         type Error = StdError;
 
@@ -210,7 +208,6 @@ mod impl_default_query_interface {
 
     #[contract(module=crate)]
     #[sv::messages(crate::default_query_interface)]
-    #[sv::custom(query=MyQuery)]
     impl DefaultQueryInterface for crate::MyContract {
         type Error = StdError;
 


### PR DESCRIPTION
There is no need for users to add `#[sv::custom]` for `impl Interface for Contract {...}`. It was used only by multitest module and it was fixed by this PR.