### PR TITLE
fix: Release-plz failing on CI due to "unknown field `dependencies_update`"

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,8 +1,8 @@
 [workspace]
 changelog_update = false
+dependencies_update = true
 
 [[package]]
 name = "sylvia-derive"
 changelog_update = true
-dependencies_update = true
 changelog_path = "./CHANGELOG.md"


### PR DESCRIPTION
Move `dependencies_update` to `workspace`.