### PR TITLE
chore: Improve errors in `sv::messages` attribute (#345)

### DIFF
--- a/sylvia-derive/src/parser/mod.rs
+++ b/sylvia-derive/src/parser/mod.rs
@@ -16,21 +16,15 @@ use syn::{
 };
 
 fn extract_generics_from_path(module: &Path) -> Punctuated<GenericArgument, Token![,]> {
-    let generics = module.segments.last().map(|segment| {
-        match segment.arguments.clone(){
-            PathArguments::AngleBracketed(generics) => {
-                generics.args
-            },
+    let generics = module
+        .segments
+        .last()
+        .map(|segment| match segment.arguments.clone() {
+            PathArguments::AngleBracketed(generics) => generics.args,
             PathArguments::None => Default::default(),
-            PathArguments::Parenthesized(generics) => {
-                emit_error!(
-                    generics.span(), "Found paranthesis wrapping generics in `sv::messages` attribute.";
-                    note = "Expected `sv::messages` attribute to be in form `#[sv::messages(Path<generics> as Type)]`"
-                );
-               Default::default()
-            }
-        }
-    }).unwrap_or_default();
+            PathArguments::Parenthesized(_) => Default::default(),
+        })
+        .unwrap_or_default();
 
     generics
 }

--- a/sylvia/tests/ui/attributes/messages/invalid_custom.rs
+++ b/sylvia/tests/ui/attributes/messages/invalid_custom.rs
@@ -1,0 +1,33 @@
+#![allow(unused_imports)]
+use sylvia::cw_std::{Response, StdResult};
+use sylvia::types::InstantiateCtx;
+
+mod interface {
+    use sylvia::cw_std::StdError;
+
+    #[sylvia::interface]
+    pub trait Interface {
+        type Error;
+    }
+
+    impl Interface for crate::Contract {
+        type Error = StdError;
+    }
+}
+
+pub struct Contract;
+
+#[sylvia::contract]
+#[sv::messages(interface: custom(wrong))]
+impl Contract {
+    pub const fn new() -> Self {
+        Contract
+    }
+
+    #[sv::msg(instantiate)]
+    pub fn instantiate(&self, ctx: InstantiateCtx) -> StdResult<Response> {
+        Ok(Response::new())
+    }
+}
+
+fn main() {}

--- a/sylvia/tests/ui/attributes/messages/invalid_custom.stderr
+++ b/sylvia/tests/ui/attributes/messages/invalid_custom.stderr
@@ -1,0 +1,8 @@
+error: Invalid custom attribute, expected one or both of: [`msg`, `query`]
+
+         = note: Expected attribute to be in form `#[sv::messages(interface: custom(msg, query))]`.
+
+  --> tests/ui/attributes/messages/invalid_custom.rs:21:34
+   |
+21 | #[sv::messages(interface: custom(wrong))]
+   |                                  ^^^^^

--- a/sylvia/tests/ui/attributes/messages/unexpected_token.rs
+++ b/sylvia/tests/ui/attributes/messages/unexpected_token.rs
@@ -1,0 +1,36 @@
+#![allow(unused_imports)]
+use sylvia::cw_std::{Empty, Response, StdResult};
+use sylvia::types::InstantiateCtx;
+
+mod interface {
+    use sylvia::cw_std::{Empty, StdError};
+    use sylvia::types::CustomMsg;
+
+    #[sylvia::interface]
+    pub trait Interface {
+        type Error;
+        type ParamT: CustomMsg;
+    }
+
+    impl Interface for crate::Contract {
+        type Error = StdError;
+        type ParamT = Empty;
+    }
+}
+
+pub struct Contract;
+
+#[sylvia::contract]
+#[sv::messages(interface(Empty))]
+impl Contract {
+    pub const fn new() -> Self {
+        Contract
+    }
+
+    #[sv::msg(instantiate)]
+    pub fn instantiate(&self, ctx: InstantiateCtx) -> StdResult<Response> {
+        Ok(Response::new())
+    }
+}
+
+fn main() {}

--- a/sylvia/tests/ui/attributes/messages/unexpected_token.stderr
+++ b/sylvia/tests/ui/attributes/messages/unexpected_token.stderr
@@ -1,0 +1,14 @@
+error: Unexpected tokens inside `sv::messages` attribtue.
+
+         = note: Maximal supported form of attribute: `#[sv::messages(interface::path<T1, T2> as InterfaceName: custom(msg, query))]`.
+
+  --> tests/ui/attributes/messages/unexpected_token.rs:24:25
+   |
+24 | #[sv::messages(interface(Empty))]
+   |                         ^
+
+error: unexpected token
+  --> tests/ui/attributes/messages/unexpected_token.rs:24:1
+   |
+24 | #[sv::messages(interface(Empty))]
+   | ^


### PR DESCRIPTION
closes #345 