### PR TITLE
fix: Add missing `map_err` on `IntoResponse` result

### DIFF
--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -653,6 +653,7 @@ dependencies = [
  "generic",
  "serde",
  "sylvia",
+ "thiserror",
 ]
 
 [[package]]

--- a/examples/contracts/generics_forwarded/Cargo.toml
+++ b/examples/contracts/generics_forwarded/Cargo.toml
@@ -27,6 +27,7 @@ sylvia = { path = "../../../sylvia" }
 generic = { path = "../../interfaces/generic" }
 custom-and-generic = { path = "../../interfaces/custom-and-generic/" }
 cw1 = { path = "../../interfaces/cw1/" }
+thiserror = { workspace = true }
 
 [dev-dependencies]
 anyhow = { workspace = true }

--- a/examples/contracts/generics_forwarded/src/contract.rs
+++ b/examples/contracts/generics_forwarded/src/contract.rs
@@ -1,4 +1,5 @@
-use cosmwasm_std::{Reply, Response, StdResult};
+use crate::error::ContractError;
+use cosmwasm_std::{Reply, Response};
 use cw_storage_plus::Item;
 use serde::Deserialize;
 use sylvia::types::{
@@ -51,6 +52,7 @@ pub struct GenericsForwardedContract<
 
 #[cfg_attr(not(feature = "library"), sylvia::entry_points(generics<SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomQuery, String>, custom(msg=SvCustomMsg, query=SvCustomQuery)))]
 #[contract]
+#[sv::error(ContractError)]
 #[sv::messages(generic<Exec1T, Exec2T, Exec3T, Query1T, Query2T, Query3T, Sudo1T, Sudo2T, Sudo3T, SvCustomMsg> as Generic: custom(msg, query))]
 #[sv::messages(cw1 as Cw1: custom(msg, query))]
 #[sv::messages(custom_and_generic<Exec1T, Exec2T, Exec3T, Query1T, Query2T, Query3T, Sudo1T, Sudo2T, Sudo3T, SvCustomMsg> as CustomAndGeneric)]
@@ -115,7 +117,7 @@ where
         &self,
         _ctx: InstantiateCtx<CustomQueryT>,
         _msg: InstantiateT,
-    ) -> StdResult<Response<CustomMsgT>> {
+    ) -> Result<Response<CustomMsgT>, ContractError> {
         Ok(Response::new())
     }
 
@@ -125,7 +127,7 @@ where
         _ctx: ExecCtx<CustomQueryT>,
         _msg1: Exec1T,
         _msg2: Exec2T,
-    ) -> StdResult<Response<CustomMsgT>> {
+    ) -> Result<Response<CustomMsgT>, ContractError> {
         Ok(Response::new())
     }
 
@@ -135,7 +137,7 @@ where
         _ctx: ExecCtx<CustomQueryT>,
         _msg1: Exec2T,
         _msg2: Exec3T,
-    ) -> StdResult<Response<CustomMsgT>> {
+    ) -> Result<Response<CustomMsgT>, ContractError> {
         Ok(Response::new())
     }
 
@@ -145,7 +147,7 @@ where
         _ctx: QueryCtx<CustomQueryT>,
         _msg1: Query1T,
         _msg2: Query2T,
-    ) -> StdResult<String> {
+    ) -> Result<String, ContractError> {
         Ok(String::default())
     }
 
@@ -155,7 +157,7 @@ where
         _ctx: QueryCtx<CustomQueryT>,
         _msg1: Query2T,
         _msg2: Query3T,
-    ) -> StdResult<String> {
+    ) -> Result<String, ContractError> {
         Ok(String::default())
     }
 
@@ -165,7 +167,7 @@ where
         _ctx: SudoCtx<CustomQueryT>,
         _msgs1: Sudo1T,
         _msgs2: Sudo2T,
-    ) -> StdResult<Response<CustomMsgT>> {
+    ) -> Result<Response<CustomMsgT>, ContractError> {
         Ok(Response::new())
     }
 
@@ -175,7 +177,7 @@ where
         _ctx: SudoCtx<CustomQueryT>,
         _msgs1: Sudo2T,
         _msgs2: Sudo3T,
-    ) -> StdResult<Response<CustomMsgT>> {
+    ) -> Result<Response<CustomMsgT>, ContractError> {
         Ok(Response::new())
     }
 
@@ -184,7 +186,7 @@ where
         &self,
         _ctx: MigrateCtx<CustomQueryT>,
         _msg: MigrateT,
-    ) -> StdResult<Response<CustomMsgT>> {
+    ) -> Result<Response<CustomMsgT>, ContractError> {
         Ok(Response::new())
     }
 
@@ -194,7 +196,7 @@ where
         &self,
         _ctx: ReplyCtx<CustomQueryT>,
         _reply: Reply,
-    ) -> StdResult<Response<CustomMsgT>> {
+    ) -> Result<Response<CustomMsgT>, ContractError> {
         Ok(Response::new())
     }
 }

--- a/examples/contracts/generics_forwarded/src/custom_and_generic.rs
+++ b/examples/contracts/generics_forwarded/src/custom_and_generic.rs
@@ -1,9 +1,10 @@
-use cosmwasm_std::{CosmosMsg, Response, StdError, StdResult};
+use cosmwasm_std::{CosmosMsg, Response};
 use custom_and_generic::CustomAndGeneric;
 use serde::Deserialize;
 use sylvia::types::{CustomMsg, CustomQuery, ExecCtx, QueryCtx, SudoCtx};
 
 use crate::contract::SvCustomMsg;
+use crate::error::ContractError;
 
 impl<
         InstantiateT,
@@ -53,7 +54,7 @@ where
     CustomQueryT: CustomQuery + 'static,
     FieldT: 'static,
 {
-    type Error = StdError;
+    type Error = ContractError;
     type Exec1T = Exec1T;
     type Exec2T = Exec2T;
     type Exec3T = Exec3T;
@@ -72,7 +73,7 @@ where
         _ctx: ExecCtx<Self::QueryC>,
         _msgs1: Vec<CosmosMsg<Self::Exec1T>>,
         _msgs2: Vec<CosmosMsg<Self::Exec2T>>,
-    ) -> StdResult<Response<Self::ExecC>> {
+    ) -> Result<Response<Self::ExecC>, ContractError> {
         Ok(Response::new())
     }
 
@@ -81,7 +82,7 @@ where
         _ctx: ExecCtx<Self::QueryC>,
         _msgs2: Vec<CosmosMsg<Self::Exec2T>>,
         _msgs1: Vec<CosmosMsg<Self::Exec3T>>,
-    ) -> StdResult<Response<Self::ExecC>> {
+    ) -> Result<Response<Self::ExecC>, ContractError> {
         Ok(Response::new())
     }
 
@@ -90,7 +91,7 @@ where
         _ctx: QueryCtx<Self::QueryC>,
         _msg1: Self::Query1T,
         _msg2: Self::Query2T,
-    ) -> StdResult<SvCustomMsg> {
+    ) -> Result<SvCustomMsg, ContractError> {
         Ok(SvCustomMsg {})
     }
 
@@ -99,7 +100,7 @@ where
         _ctx: QueryCtx<Self::QueryC>,
         _msg1: Self::Query2T,
         _msg2: Self::Query3T,
-    ) -> StdResult<SvCustomMsg> {
+    ) -> Result<SvCustomMsg, ContractError> {
         Ok(SvCustomMsg {})
     }
 
@@ -108,7 +109,7 @@ where
         _ctx: SudoCtx<Self::QueryC>,
         _msgs1: CosmosMsg<Self::Sudo1T>,
         _msgs2: CosmosMsg<Self::Sudo2T>,
-    ) -> StdResult<Response<Self::ExecC>> {
+    ) -> Result<Response<Self::ExecC>, ContractError> {
         Ok(Response::new())
     }
 
@@ -117,7 +118,7 @@ where
         _ctx: SudoCtx<Self::QueryC>,
         _msgs1: CosmosMsg<Self::Sudo2T>,
         _msgs2: CosmosMsg<Self::Sudo3T>,
-    ) -> StdResult<Response<Self::ExecC>> {
+    ) -> Result<Response<Self::ExecC>, ContractError> {
         Ok(Response::new())
     }
 }

--- a/examples/contracts/generics_forwarded/src/cw1.rs
+++ b/examples/contracts/generics_forwarded/src/cw1.rs
@@ -1,9 +1,11 @@
 use cosmwasm_schema::schemars::JsonSchema;
-use cosmwasm_std::{CosmosMsg, CustomMsg, Response, StdError, StdResult};
+use cosmwasm_std::{CosmosMsg, CustomMsg, Response, StdResult};
 use cw1::{CanExecuteResp, Cw1};
 use serde::de::DeserializeOwned;
 use serde::Deserialize;
 use sylvia::types::{CustomQuery, ExecCtx, QueryCtx};
+
+use crate::error::ContractError;
 
 impl<
         InstantiateT,
@@ -53,9 +55,9 @@ where
     CustomQueryT: CustomQuery + JsonSchema + 'static,
     FieldT: 'static,
 {
-    type Error = StdError;
+    type Error = ContractError;
 
-    fn execute(&self, _ctx: ExecCtx, _msgs: Vec<CosmosMsg>) -> StdResult<Response> {
+    fn execute(&self, _ctx: ExecCtx, _msgs: Vec<CosmosMsg>) -> Result<Response, Self::Error> {
         Ok(Response::new())
     }
 

--- a/examples/contracts/generics_forwarded/src/error.rs
+++ b/examples/contracts/generics_forwarded/src/error.rs
@@ -1,0 +1,8 @@
+use cosmwasm_std::StdError;
+use thiserror::Error;
+
+#[derive(Error, Debug, PartialEq)]
+pub enum ContractError {
+    #[error("{0}")]
+    Std(#[from] StdError),
+}

--- a/examples/contracts/generics_forwarded/src/generic.rs
+++ b/examples/contracts/generics_forwarded/src/generic.rs
@@ -1,9 +1,10 @@
-use cosmwasm_std::{CosmosMsg, Response, StdError, StdResult};
+use cosmwasm_std::{CosmosMsg, Response};
 use generic::Generic;
 use serde::Deserialize;
 use sylvia::types::{CustomMsg, CustomQuery, ExecCtx, QueryCtx, SudoCtx};
 
 use crate::contract::SvCustomMsg;
+use crate::error::ContractError;
 
 impl<
         InstantiateT,
@@ -53,7 +54,7 @@ where
     CustomQueryT: CustomQuery + 'static,
     FieldT: 'static,
 {
-    type Error = StdError;
+    type Error = ContractError;
     type Exec1T = Exec1T;
     type Exec2T = Exec2T;
     type Exec3T = Exec3T;
@@ -70,7 +71,7 @@ where
         _ctx: ExecCtx,
         _msgs1: Vec<CosmosMsg<Self::Exec1T>>,
         _msgs2: Vec<CosmosMsg<Self::Exec2T>>,
-    ) -> StdResult<Response> {
+    ) -> Result<Response, Self::Error> {
         Ok(Response::new())
     }
 
@@ -79,7 +80,7 @@ where
         _ctx: ExecCtx,
         _msgs2: Vec<CosmosMsg<Self::Exec2T>>,
         _msgs3: Vec<CosmosMsg<Self::Exec3T>>,
-    ) -> StdResult<Response> {
+    ) -> Result<Response, Self::Error> {
         Ok(Response::new())
     }
 
@@ -88,7 +89,7 @@ where
         _ctx: QueryCtx,
         _msg1: Self::Query1T,
         _msg2: Self::Query2T,
-    ) -> StdResult<SvCustomMsg> {
+    ) -> Result<SvCustomMsg, Self::Error> {
         Ok(SvCustomMsg {})
     }
 
@@ -97,7 +98,7 @@ where
         _ctx: QueryCtx,
         _msg1: Self::Query2T,
         _msg2: Self::Query3T,
-    ) -> StdResult<SvCustomMsg> {
+    ) -> Result<SvCustomMsg, Self::Error> {
         Ok(SvCustomMsg {})
     }
 
@@ -106,7 +107,7 @@ where
         _ctx: SudoCtx,
         _msgs1: CosmosMsg<Self::Sudo1T>,
         _msgs2: CosmosMsg<Self::Sudo2T>,
-    ) -> StdResult<Response> {
+    ) -> Result<Response, Self::Error> {
         Ok(Response::new())
     }
 
@@ -115,7 +116,7 @@ where
         _ctx: SudoCtx,
         _msgs1: CosmosMsg<Self::Sudo2T>,
         _msgs2: CosmosMsg<Self::Sudo3T>,
-    ) -> StdResult<Response> {
+    ) -> Result<Response, Self::Error> {
         Ok(Response::new())
     }
 }

--- a/examples/contracts/generics_forwarded/src/lib.rs
+++ b/examples/contracts/generics_forwarded/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod contract;
 pub mod custom_and_generic;
 pub mod cw1;
+pub mod error;
 pub mod generic;

--- a/sylvia-derive/src/interfaces.rs
+++ b/sylvia-derive/src/interfaces.rs
@@ -122,7 +122,7 @@ impl Interfaces {
 
             match (msg_ty, customs.has_msg) {
                 (MsgType::Exec, true) | (MsgType::Sudo, true) => quote! {
-                    #contract_enum_name:: #variant(msg) => #sylvia ::into_response::IntoResponse::into_response(msg.dispatch(contract, Into::into( #ctx ))?)
+                    #contract_enum_name:: #variant(msg) => #sylvia ::into_response::IntoResponse::into_response(msg.dispatch(contract, Into::into( #ctx ))?).map_err(Into::into)
                 },
                 _ => quote! {
                     #contract_enum_name :: #variant(msg) => msg.dispatch(contract, Into::into( #ctx ))


### PR DESCRIPTION
`IntoResponse` couldn't be used in parallel with custom error type.