### PR TITLE
feat: Remove types forwarding to interface in sv::messages

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -2,6 +2,53 @@
 
 This guide explains what is needed to upgrade contracts when migrating over major releases of `sylvia`. Note that you can also view the [complete CHANGELOG](https://github.com/CosmWasm/sylvia/blob/main/CHANGELOG.md) to understand the differences.
 
+
+## 1.0.2 ->
+
+
+### Generics in `sv::messages` not required
+```diff
+-#[contract]
+-#[sv::messages(generic<SomeType1, SomeType2, SomeType3> as Generic
+-impl Contract {}
++#[contract]
++#[sv::messages(generic as Generic)]
++impl Contract {}
+```
+
+This change is optional, since the generics are still accepted by the parser. Though they are
+ignored in the further process.
+
+
+### CodeId generic over the Contract type
+```diff
+-let code_id: CodeId<
+-    SvCustomMsg,
+-    SvCustomMsg,
+-    _,
+-> = CodeId::store_code(&app);
++let code_id: CodeId<
++    GenericContract<
++        SvCustomMsg,
++        SvCustomMsg,
++    >,
++    _,
++> = CodeId::store_code(&app);
+```
+
+### Lifetime ellision in a contract's impl block not supported
+```diff
+-#[contract]
+-impl Cw1SubkeysContract<'_> {
+-    // [...]
+-}
++#[contract]
++impl<'a> Cw1SubkeysContract<'a> {
++    // [...]
++}
+```
+
+
 ## 0.9.3 -> 0.10.0
 
 ## Multitest proxy

--- a/README.md
+++ b/README.md
@@ -689,58 +689,6 @@ where
 }
 ```
 
-### Implement interface
-
-```rust
-impl<InstantiateParam, ExecParam, FieldType>
-    Generic
-    for crate::contract::GenericContract<
-        InstantiateParam,
-        ExecParam,
-        FieldType,
-    >
-{
-    type Error = StdError;
-    type ExecParam = ExecParam;
-    type QueryParam: SvCustomMsg;
-    type RetType = SvCustomMsg;
-
-    fn generic_exec(
-        &self,
-        _ctx: ExecCtx,
-        _msgs: Vec<CosmosMsg<Self::ExecParam>>,
-    ) -> StdResult<Response> {
-        Ok(Response::new())
-    }
-
-    fn generic_query(
-        &self,
-        _ctx: QueryCtx,
-        _msg: Self::QueryParam,
-    ) -> StdResult<Self::RetType> {
-        Ok(SvCustomMsg {})
-    }
-}
-```
-
-Now we have to inform Sylvia that the interface implemented for the contract has associated types.
-We have to list those types (generics or concrete) next to the interface in the `#[sv::messages]`
-attribute:
-
-```rust
-#[contract]
-#[sv::messages(generic<ExecParam, SvCustomMsg, SvCustomMsg> as Generic)]
-impl<InstantiateParam, ExecParam, FieldType>
-    GenericContract<InstantiateParam, ExecParam, FieldType>
-where
-    for<'msg_de> InstantiateParam: CustomMsg + Deserialize<'msg_de> + 'msg_de,
-    ExecParam: CustomMsg + DeserializeOwned + 'static,
-    FieldType: 'static,
-{
-    ...
-}
-```
-
 ### Generics in entry_points
 
 Entry points have to be generated with concrete types. Using the `entry_points` macro

--- a/examples/contracts/cw1-subkeys/src/contract.rs
+++ b/examples/contracts/cw1-subkeys/src/contract.rs
@@ -36,7 +36,7 @@ pub struct Cw1SubkeysContract<'a> {
 #[sv::error(ContractError)]
 #[sv::messages(cw1 as Cw1)]
 #[sv::messages(whitelist as Whitelist)]
-impl Cw1SubkeysContract<'_> {
+impl<'abcd> Cw1SubkeysContract<'abcd> {
     pub const fn new() -> Self {
         Self {
             whitelist: Cw1WhitelistContract::new(),

--- a/examples/contracts/cw1-whitelist/src/contract.rs
+++ b/examples/contracts/cw1-whitelist/src/contract.rs
@@ -22,7 +22,7 @@ pub struct Cw1WhitelistContract<'a> {
 #[sv::error(ContractError)]
 #[sv::messages(cw1 as Cw1)]
 #[sv::messages(whitelist as Whitelist)]
-impl Cw1WhitelistContract<'_> {
+impl<'a> Cw1WhitelistContract<'a> {
     pub const fn new() -> Self {
         Self {
             admins: Map::new("admins"),

--- a/examples/contracts/cw20-base/src/contract.rs
+++ b/examples/contracts/cw20-base/src/contract.rs
@@ -78,7 +78,7 @@ pub struct Cw20Base<'a> {
 #[sv::messages(cw20_allowances as Allowances)]
 #[sv::messages(cw20_marketing as Marketing)]
 #[sv::messages(cw20_minting as Minting)]
-impl Cw20Base<'_> {
+impl<'abcd> Cw20Base<'abcd> {
     pub const fn new() -> Self {
         Self {
             token_info: Item::new("token_info"),

--- a/examples/contracts/generic_contract/src/bin/schema.rs
+++ b/examples/contracts/generic_contract/src/bin/schema.rs
@@ -7,7 +7,7 @@ fn main() {
 
     write_api! {
         instantiate: InstantiateMsg<SvCustomMsg>,
-        execute: ContractExecMsg<SvCustomMsg, SvCustomMsg, SvCustomMsg>,
-        query: ContractQueryMsg<SvCustomMsg>,
+        execute: ContractExecMsg<SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg,>,
+        query: ContractQueryMsg<SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg,>,
     }
 }

--- a/examples/contracts/generic_contract/src/contract.rs
+++ b/examples/contracts/generic_contract/src/contract.rs
@@ -50,8 +50,8 @@ pub struct GenericContract<
 #[cfg_attr(not(feature = "library"), entry_points(generics<SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg, String>))]
 #[contract]
 #[sv::messages(cw1 as Cw1: custom(msg, query))]
-#[sv::messages(generic<SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg> as Generic: custom(msg, query))]
-#[sv::messages(custom_and_generic<SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg> as CustomAndGeneric)]
+#[sv::messages(generic as Generic: custom(msg, query))]
+#[sv::messages(custom_and_generic as CustomAndGeneric)]
 #[sv::custom(msg=SvCustomMsg, query=SvCustomQuery)]
 impl<
         InstantiateT,
@@ -194,7 +194,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::sv::mt::CodeId;
-    use super::{SvCustomMsg, SvCustomQuery};
+    use super::{GenericContract, SvCustomMsg, SvCustomQuery};
     use crate::contract::sv::mt::GenericContractProxy;
     use cw_multi_test::IntoBech32;
     use sylvia::multitest::App;
@@ -204,18 +204,20 @@ mod tests {
         let app = App::<cw_multi_test::BasicApp<SvCustomMsg, SvCustomQuery>>::custom(|_, _, _| {});
         #[allow(clippy::type_complexity)]
         let code_id: CodeId<
-            SvCustomMsg,
-            SvCustomMsg,
-            SvCustomMsg,
-            SvCustomMsg,
-            SvCustomMsg,
-            SvCustomMsg,
-            SvCustomMsg,
-            SvCustomMsg,
-            SvCustomMsg,
-            SvCustomMsg,
-            SvCustomMsg,
-            String,
+            GenericContract<
+                SvCustomMsg,
+                SvCustomMsg,
+                SvCustomMsg,
+                SvCustomMsg,
+                SvCustomMsg,
+                SvCustomMsg,
+                SvCustomMsg,
+                SvCustomMsg,
+                SvCustomMsg,
+                SvCustomMsg,
+                SvCustomMsg,
+                String,
+            >,
             _,
         > = CodeId::store_code(&app);
 

--- a/examples/contracts/generic_contract/src/custom_and_generic.rs
+++ b/examples/contracts/generic_contract/src/custom_and_generic.rs
@@ -2,7 +2,7 @@ use cosmwasm_std::{CosmosMsg, Response, StdError, StdResult};
 use custom_and_generic::CustomAndGeneric;
 use sylvia::types::{ExecCtx, QueryCtx, SudoCtx};
 
-use crate::contract::{SvCustomMsg, SvCustomQuery};
+use crate::contract::{GenericContract, SvCustomMsg, SvCustomQuery};
 
 impl<
         InstantiateT,
@@ -18,7 +18,7 @@ impl<
         MigrateT,
         FieldT,
     > CustomAndGeneric
-    for crate::contract::GenericContract<
+    for GenericContract<
         InstantiateT,
         Exec1T,
         Exec2T,
@@ -104,7 +104,7 @@ impl<
 
 #[cfg(test)]
 mod tests {
-    use super::{SvCustomMsg, SvCustomQuery};
+    use super::{GenericContract, SvCustomMsg, SvCustomQuery};
     use crate::contract::sv::mt::CodeId;
     use custom_and_generic::sv::mt::CustomAndGenericProxy;
     use cw_multi_test::IntoBech32;
@@ -114,18 +114,20 @@ mod tests {
     fn proxy_methods() {
         let app = App::<cw_multi_test::BasicApp<SvCustomMsg, SvCustomQuery>>::custom(|_, _, _| {});
         let code_id = CodeId::<
-            SvCustomMsg,
-            SvCustomMsg,
-            SvCustomMsg,
-            SvCustomMsg,
-            SvCustomMsg,
-            SvCustomMsg,
-            SvCustomMsg,
-            SvCustomMsg,
-            SvCustomMsg,
-            SvCustomMsg,
-            SvCustomMsg,
-            String,
+            GenericContract<
+                SvCustomMsg,
+                SvCustomMsg,
+                SvCustomMsg,
+                SvCustomMsg,
+                SvCustomMsg,
+                SvCustomMsg,
+                SvCustomMsg,
+                SvCustomMsg,
+                SvCustomMsg,
+                SvCustomMsg,
+                SvCustomMsg,
+                String,
+            >,
             _,
         >::store_code(&app);
 

--- a/examples/contracts/generic_contract/src/cw1.rs
+++ b/examples/contracts/generic_contract/src/cw1.rs
@@ -1,3 +1,4 @@
+use crate::contract::GenericContract;
 use cosmwasm_std::{CosmosMsg, Response, StdError, StdResult};
 use cw1::{CanExecuteResp, Cw1};
 use sylvia::types::{ExecCtx, QueryCtx};
@@ -16,7 +17,7 @@ impl<
         MigrateT,
         FieldT,
     > Cw1
-    for crate::contract::GenericContract<
+    for GenericContract<
         InstantiateT,
         Exec1T,
         Exec2T,
@@ -50,7 +51,7 @@ impl<
 #[cfg(test)]
 mod tests {
     use crate::contract::sv::mt::CodeId;
-    use crate::contract::{SvCustomMsg, SvCustomQuery};
+    use crate::contract::{GenericContract, SvCustomMsg, SvCustomQuery};
     use cosmwasm_std::{CosmosMsg, Empty};
     use cw1::sv::mt::Cw1Proxy;
     use cw_multi_test::IntoBech32;
@@ -60,18 +61,20 @@ mod tests {
     fn proxy_methods() {
         let app = App::<cw_multi_test::BasicApp<SvCustomMsg, SvCustomQuery>>::custom(|_, _, _| {});
         let code_id = CodeId::<
-            SvCustomMsg,
-            SvCustomMsg,
-            SvCustomMsg,
-            SvCustomMsg,
-            SvCustomMsg,
-            SvCustomMsg,
-            SvCustomMsg,
-            SvCustomMsg,
-            SvCustomMsg,
-            SvCustomMsg,
-            SvCustomMsg,
-            String,
+            GenericContract<
+                SvCustomMsg,
+                SvCustomMsg,
+                SvCustomMsg,
+                SvCustomMsg,
+                SvCustomMsg,
+                SvCustomMsg,
+                SvCustomMsg,
+                SvCustomMsg,
+                SvCustomMsg,
+                SvCustomMsg,
+                SvCustomMsg,
+                String,
+            >,
             _,
         >::store_code(&app);
 

--- a/examples/contracts/generic_contract/src/generic.rs
+++ b/examples/contracts/generic_contract/src/generic.rs
@@ -3,7 +3,7 @@ use generic::Generic;
 use serde::Deserialize;
 use sylvia::types::{CustomMsg, ExecCtx, QueryCtx, SudoCtx};
 
-use crate::contract::SvCustomMsg;
+use crate::contract::{GenericContract, SvCustomMsg};
 
 impl<
         InstantiateT,
@@ -19,7 +19,7 @@ impl<
         MigrateT,
         FieldT,
     > Generic
-    for crate::contract::GenericContract<
+    for GenericContract<
         InstantiateT,
         Exec1T,
         Exec2T,
@@ -117,7 +117,7 @@ where
 #[cfg(test)]
 mod tests {
     use crate::contract::sv::mt::CodeId;
-    use crate::contract::{SvCustomMsg, SvCustomQuery};
+    use crate::contract::{GenericContract, SvCustomMsg, SvCustomQuery};
     use cosmwasm_std::CosmosMsg;
     use cw_multi_test::IntoBech32;
     use generic::sv::mt::GenericProxy;
@@ -128,18 +128,20 @@ mod tests {
         let app = App::<cw_multi_test::BasicApp<SvCustomMsg, SvCustomQuery>>::custom(|_, _, _| {});
         #[allow(clippy::type_complexity)]
         let code_id: CodeId<
-            SvCustomMsg,
-            SvCustomMsg,
-            SvCustomMsg,
-            SvCustomMsg,
-            SvCustomMsg,
-            SvCustomMsg,
-            SvCustomMsg,
-            SvCustomMsg,
-            SvCustomMsg,
-            SvCustomMsg,
-            SvCustomMsg,
-            String,
+            GenericContract<
+                SvCustomMsg,
+                SvCustomMsg,
+                SvCustomMsg,
+                SvCustomMsg,
+                SvCustomMsg,
+                SvCustomMsg,
+                SvCustomMsg,
+                SvCustomMsg,
+                SvCustomMsg,
+                SvCustomMsg,
+                SvCustomMsg,
+                String,
+            >,
             _,
         > = CodeId::store_code(&app);
 

--- a/examples/contracts/generic_iface_on_contract/src/contract.rs
+++ b/examples/contracts/generic_iface_on_contract/src/contract.rs
@@ -17,8 +17,8 @@ impl cosmwasm_std::CustomQuery for SvCustomQuery {}
 
 #[cfg_attr(not(feature = "library"), entry_points)]
 #[contract]
-#[sv::messages(generic<SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg> as Generic: custom(msg, query))]
-#[sv::messages(custom_and_generic<SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg> as CustomAndGeneric)]
+#[sv::messages(generic as Generic: custom(msg, query))]
+#[sv::messages(custom_and_generic as CustomAndGeneric)]
 #[sv::messages(cw1 as Cw1: custom(msg, query))]
 /// Required if interface returns generic `Response`
 #[sv::custom(msg=SvCustomMsg, query=SvCustomQuery)]

--- a/examples/contracts/generics_forwarded/src/bin/schema.rs
+++ b/examples/contracts/generics_forwarded/src/bin/schema.rs
@@ -3,7 +3,7 @@ use cosmwasm_schema::write_api;
 #[cfg(not(tarpaulin_include))]
 fn main() {
     use generics_forwarded::contract::sv::{ContractExecMsg, ContractQueryMsg, InstantiateMsg};
-    use generics_forwarded::contract::SvCustomMsg;
+    use generics_forwarded::contract::{SvCustomMsg, SvCustomQuery};
 
     write_api! {
         instantiate: InstantiateMsg<SvCustomMsg>,
@@ -18,7 +18,7 @@ fn main() {
         // This potentially could be done with some type alias, not sure how it would affect the
         // schema.
         // execute: <GenericForwardedContract as ContractApi>::ContractExec,
-        execute: ContractExecMsg<SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg>,
-        query: ContractQueryMsg<SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg>,
+        execute: ContractExecMsg<SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomQuery, String>,
+        query: ContractQueryMsg<SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomQuery, String>,
     }
 }

--- a/examples/contracts/generics_forwarded/src/contract.rs
+++ b/examples/contracts/generics_forwarded/src/contract.rs
@@ -53,9 +53,9 @@ pub struct GenericsForwardedContract<
 #[cfg_attr(not(feature = "library"), sylvia::entry_points(generics<SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomQuery, String>, custom(msg=SvCustomMsg, query=SvCustomQuery)))]
 #[contract]
 #[sv::error(ContractError)]
-#[sv::messages(generic<Exec1T, Exec2T, Exec3T, Query1T, Query2T, Query3T, Sudo1T, Sudo2T, Sudo3T, SvCustomMsg> as Generic: custom(msg, query))]
+#[sv::messages(generic as Generic: custom(msg, query))]
 #[sv::messages(cw1 as Cw1: custom(msg, query))]
-#[sv::messages(custom_and_generic<Exec1T, Exec2T, Exec3T, Query1T, Query2T, Query3T, Sudo1T, Sudo2T, Sudo3T, SvCustomMsg> as CustomAndGeneric)]
+#[sv::messages(custom_and_generic as CustomAndGeneric)]
 #[sv::custom(msg=CustomMsgT, query=CustomQueryT)]
 impl<
         InstantiateT,
@@ -204,7 +204,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::sv::mt::CodeId;
-    use super::{SvCustomMsg, SvCustomQuery};
+    use super::{GenericsForwardedContract, SvCustomMsg, SvCustomQuery};
     use crate::contract::sv::mt::GenericsForwardedContractProxy;
     use cw_multi_test::IntoBech32;
     use sylvia::multitest::App;
@@ -214,20 +214,22 @@ mod tests {
         let app = App::<cw_multi_test::BasicApp<SvCustomMsg, SvCustomQuery>>::custom(|_, _, _| {});
         #[allow(clippy::type_complexity)]
         let code_id: CodeId<
-            SvCustomMsg,
-            SvCustomMsg,
-            SvCustomMsg,
-            SvCustomMsg,
-            SvCustomMsg,
-            SvCustomMsg,
-            SvCustomMsg,
-            SvCustomMsg,
-            SvCustomMsg,
-            SvCustomMsg,
-            SvCustomMsg,
-            SvCustomMsg,
-            SvCustomQuery,
-            String,
+            GenericsForwardedContract<
+                SvCustomMsg,
+                SvCustomMsg,
+                SvCustomMsg,
+                SvCustomMsg,
+                SvCustomMsg,
+                SvCustomMsg,
+                SvCustomMsg,
+                SvCustomMsg,
+                SvCustomMsg,
+                SvCustomMsg,
+                SvCustomMsg,
+                SvCustomMsg,
+                SvCustomQuery,
+                String,
+            >,
             _,
         > = CodeId::store_code(&app);
 

--- a/examples/contracts/generics_forwarded/src/custom_and_generic.rs
+++ b/examples/contracts/generics_forwarded/src/custom_and_generic.rs
@@ -3,7 +3,7 @@ use custom_and_generic::CustomAndGeneric;
 use serde::Deserialize;
 use sylvia::types::{CustomMsg, CustomQuery, ExecCtx, QueryCtx, SudoCtx};
 
-use crate::contract::SvCustomMsg;
+use crate::contract::{GenericsForwardedContract, SvCustomMsg};
 use crate::error::ContractError;
 
 impl<
@@ -22,7 +22,7 @@ impl<
         CustomQueryT,
         FieldT,
     > CustomAndGeneric
-    for crate::contract::GenericsForwardedContract<
+    for GenericsForwardedContract<
         InstantiateT,
         Exec1T,
         Exec2T,
@@ -126,7 +126,7 @@ where
 #[cfg(test)]
 mod tests {
     use crate::contract::sv::mt::CodeId;
-    use crate::contract::{SvCustomMsg, SvCustomQuery};
+    use crate::contract::{GenericsForwardedContract, SvCustomMsg, SvCustomQuery};
     use cosmwasm_std::CosmosMsg;
     use custom_and_generic::sv::mt::CustomAndGenericProxy;
     use cw_multi_test::IntoBech32;
@@ -136,20 +136,22 @@ mod tests {
     fn proxy_methods() {
         let app = App::<cw_multi_test::BasicApp<SvCustomMsg, SvCustomQuery>>::custom(|_, _, _| {});
         let code_id = CodeId::<
-            SvCustomMsg,
-            SvCustomMsg,
-            SvCustomMsg,
-            SvCustomMsg,
-            SvCustomMsg,
-            SvCustomMsg,
-            SvCustomMsg,
-            SvCustomMsg,
-            SvCustomMsg,
-            SvCustomMsg,
-            SvCustomMsg,
-            SvCustomMsg,
-            SvCustomQuery,
-            String,
+            GenericsForwardedContract<
+                SvCustomMsg,
+                SvCustomMsg,
+                SvCustomMsg,
+                SvCustomMsg,
+                SvCustomMsg,
+                SvCustomMsg,
+                SvCustomMsg,
+                SvCustomMsg,
+                SvCustomMsg,
+                SvCustomMsg,
+                SvCustomMsg,
+                SvCustomMsg,
+                SvCustomQuery,
+                String,
+            >,
             _,
         >::store_code(&app);
 

--- a/examples/contracts/generics_forwarded/src/cw1.rs
+++ b/examples/contracts/generics_forwarded/src/cw1.rs
@@ -5,6 +5,7 @@ use serde::de::DeserializeOwned;
 use serde::Deserialize;
 use sylvia::types::{CustomQuery, ExecCtx, QueryCtx};
 
+use crate::contract::GenericsForwardedContract;
 use crate::error::ContractError;
 
 impl<
@@ -23,7 +24,7 @@ impl<
         CustomQueryT,
         FieldT,
     > Cw1
-    for crate::contract::GenericsForwardedContract<
+    for GenericsForwardedContract<
         InstantiateT,
         Exec1T,
         Exec2T,
@@ -74,7 +75,7 @@ where
 #[cfg(test)]
 mod tests {
     use crate::contract::sv::mt::CodeId;
-    use crate::contract::{SvCustomMsg, SvCustomQuery};
+    use crate::contract::{GenericsForwardedContract, SvCustomMsg, SvCustomQuery};
     use cosmwasm_std::{CosmosMsg, Empty};
     use cw1::sv::mt::Cw1Proxy;
     use cw_multi_test::IntoBech32;
@@ -84,20 +85,22 @@ mod tests {
     fn proxy_methods() {
         let app = App::<cw_multi_test::BasicApp<SvCustomMsg, SvCustomQuery>>::custom(|_, _, _| {});
         let code_id = CodeId::<
-            SvCustomMsg,
-            SvCustomMsg,
-            SvCustomMsg,
-            SvCustomMsg,
-            SvCustomMsg,
-            SvCustomMsg,
-            SvCustomMsg,
-            SvCustomMsg,
-            SvCustomMsg,
-            SvCustomMsg,
-            SvCustomMsg,
-            SvCustomMsg,
-            SvCustomQuery,
-            String,
+            GenericsForwardedContract<
+                SvCustomMsg,
+                SvCustomMsg,
+                SvCustomMsg,
+                SvCustomMsg,
+                SvCustomMsg,
+                SvCustomMsg,
+                SvCustomMsg,
+                SvCustomMsg,
+                SvCustomMsg,
+                SvCustomMsg,
+                SvCustomMsg,
+                SvCustomMsg,
+                SvCustomQuery,
+                String,
+            >,
             _,
         >::store_code(&app);
 

--- a/examples/contracts/generics_forwarded/src/generic.rs
+++ b/examples/contracts/generics_forwarded/src/generic.rs
@@ -3,7 +3,7 @@ use generic::Generic;
 use serde::Deserialize;
 use sylvia::types::{CustomMsg, CustomQuery, ExecCtx, QueryCtx, SudoCtx};
 
-use crate::contract::SvCustomMsg;
+use crate::contract::{GenericsForwardedContract, SvCustomMsg};
 use crate::error::ContractError;
 
 impl<
@@ -22,7 +22,7 @@ impl<
         CustomQueryT,
         FieldT,
     > Generic
-    for crate::contract::GenericsForwardedContract<
+    for GenericsForwardedContract<
         InstantiateT,
         Exec1T,
         Exec2T,
@@ -124,7 +124,7 @@ where
 #[cfg(test)]
 mod tests {
     use crate::contract::sv::mt::CodeId;
-    use crate::contract::{SvCustomMsg, SvCustomQuery};
+    use crate::contract::{GenericsForwardedContract, SvCustomMsg, SvCustomQuery};
     use cosmwasm_std::CosmosMsg;
     use cw_multi_test::IntoBech32;
     use generic::sv::mt::GenericProxy;
@@ -135,20 +135,22 @@ mod tests {
         let app = App::<cw_multi_test::BasicApp<SvCustomMsg, SvCustomQuery>>::custom(|_, _, _| {});
         #[allow(clippy::type_complexity)]
         let code_id: CodeId<
-            SvCustomMsg,
-            SvCustomMsg,
-            SvCustomMsg,
-            SvCustomMsg,
-            SvCustomMsg,
-            SvCustomMsg,
-            SvCustomMsg,
-            SvCustomMsg,
-            SvCustomMsg,
-            SvCustomMsg,
-            SvCustomMsg,
-            SvCustomMsg,
-            SvCustomQuery,
-            String,
+            GenericsForwardedContract<
+                SvCustomMsg,
+                SvCustomMsg,
+                SvCustomMsg,
+                SvCustomMsg,
+                SvCustomMsg,
+                SvCustomMsg,
+                SvCustomMsg,
+                SvCustomMsg,
+                SvCustomMsg,
+                SvCustomMsg,
+                SvCustomMsg,
+                SvCustomMsg,
+                SvCustomQuery,
+                String,
+            >,
             _,
         > = CodeId::store_code(&app);
 

--- a/sylvia-derive/src/input.rs
+++ b/sylvia-derive/src/input.rs
@@ -200,14 +200,13 @@ impl<'a> ImplInput<'a> {
             item,
             generics,
             custom,
-            interfaces,
             ..
         } = self;
         let multitest_helpers = self.emit_multitest_helpers();
 
         let querier = ContractQuerier::new(item).emit();
         let messages = self.emit_messages();
-        let contract_api = ContractApi::new(item, generics, custom, interfaces).emit();
+        let contract_api = ContractApi::new(item, generics, custom).emit();
 
         quote! {
             pub mod sv {
@@ -264,16 +263,12 @@ impl<'a> ImplInput<'a> {
     }
 
     fn emit_glue_msg(&self, msg_ty: MsgType) -> TokenStream {
-        let Self { generics, item, .. } = self;
-        let where_clause = &item.generics.where_clause;
-        let variants = MsgVariants::new(item.as_variants(), msg_ty, generics, where_clause);
         GlueMessage::new(
             self.item,
             msg_ty,
             &self.error,
             &self.custom,
             &self.interfaces,
-            variants,
         )
         .emit()
     }

--- a/sylvia-derive/src/message.rs
+++ b/sylvia-derive/src/message.rs
@@ -9,12 +9,11 @@ use crate::parser::{
 use crate::strip_generics::StripGenerics;
 use crate::strip_self_path::StripSelfPath;
 use crate::utils::{
-    as_where_clause, emit_bracketed_generics, extract_return_type, filter_generics, filter_wheres,
-    process_fields, SvCasing,
+    as_where_clause, emit_bracketed_generics, extract_return_type, filter_wheres, process_fields,
+    SvCasing,
 };
 use crate::variant_descs::{AsVariantDescs, VariantDescs};
 use convert_case::{Case, Casing};
-use itertools::Itertools;
 use proc_macro2::{Span, TokenStream};
 use proc_macro_error::emit_error;
 use quote::{quote, ToTokens};
@@ -817,7 +816,6 @@ pub struct GlueMessage<'a> {
     error: &'a ContractErrorAttr,
     custom: &'a Custom,
     interfaces: &'a Interfaces,
-    variants: MsgVariants<'a, GenericParam>,
 }
 
 impl<'a> GlueMessage<'a> {
@@ -827,7 +825,6 @@ impl<'a> GlueMessage<'a> {
         error: &'a ContractErrorAttr,
         custom: &'a Custom,
         interfaces: &'a Interfaces,
-        variants: MsgVariants<'a, GenericParam>,
     ) -> Self {
         GlueMessage {
             source,
@@ -836,7 +833,6 @@ impl<'a> GlueMessage<'a> {
             error,
             custom,
             interfaces,
-            variants,
         }
     }
 
@@ -849,54 +845,27 @@ impl<'a> GlueMessage<'a> {
             error,
             custom,
             interfaces,
-            variants,
+            ..
         } = self;
 
         let generics: Vec<_> = source.generics.params.iter().collect();
-        let interface_generic_args = interfaces.as_generic_args();
-        let interface_used_generics = filter_generics(&generics, &interface_generic_args);
-        let used_generics = variants.used_generics();
-
-        let wrapper_generics: Vec<_> = interface_used_generics
-            .iter()
-            .chain(used_generics.iter())
-            .unique()
-            .copied()
-            .collect();
-
-        let unused_generics: Vec<_> = variants
-            .unused_generics()
-            .iter()
-            .filter(|unused| !wrapper_generics.iter().any(|used| used == *unused))
-            .collect();
-
         let full_where_clause = &source.generics.where_clause;
-        let wrapper_predicates = filter_wheres(full_where_clause, &generics, &wrapper_generics);
-        let wrapper_where_clause = if !wrapper_predicates.is_empty() {
-            quote! { where #(#wrapper_predicates,)* }
-        } else {
-            quote! {}
+        let bracketed_wrapper_generics = match generics.is_empty() {
+            true => quote! {},
+            false => quote! { < #(#generics,)* > },
         };
 
-        let unused_generics = emit_bracketed_generics(&unused_generics);
-        let bracketed_used_generics = emit_bracketed_generics(used_generics);
-        let bracketed_wrapper_generics = emit_bracketed_generics(&wrapper_generics);
-
         let contract_enum_name = msg_ty.emit_msg_wrapper_name();
-        let enum_name = msg_ty.emit_msg_name();
+        let enum_accessor = msg_ty.as_accessor_name();
         let contract_name = StripGenerics.fold_type((*contract).clone());
 
-        let variants = interfaces.emit_glue_message_variants(msg_ty);
+        let variants = interfaces.emit_glue_message_variants(msg_ty, contract);
+        let types = interfaces.emit_glue_message_types(msg_ty, contract);
 
         let ep_name = msg_ty.emit_ep_name();
         let messages_fn_name = Ident::new(&format!("{}_messages", ep_name), contract.span());
-        let contract_variant = quote! { #contract_name ( #enum_name #bracketed_used_generics ) };
+        let contract_variant = quote! { #contract_name ( <#contract as #sylvia ::types::ContractApi> :: #enum_accessor ) };
         let mut messages_call = interfaces.emit_messages_call(msg_ty);
-        let prefixed_used_generics = if !used_generics.is_empty() {
-            quote! { :: #bracketed_used_generics }
-        } else {
-            quote! {}
-        };
         messages_call.push(quote! { &#messages_fn_name() });
 
         let variants_cnt = messages_call.len();
@@ -921,15 +890,15 @@ impl<'a> GlueMessage<'a> {
         let ctx_type = msg_ty.emit_ctx_type(&custom.query_or_default());
         let ret_type = msg_ty.emit_result_type(&custom.msg_or_default(), &error.error);
 
-        let mut response_schemas_calls = interfaces.emit_response_schemas_calls(msg_ty);
+        let mut response_schemas_calls = interfaces.emit_response_schemas_calls(msg_ty, contract);
         response_schemas_calls
-            .push(quote! {#enum_name #prefixed_used_generics :: response_schemas_impl()});
+            .push(quote! {<#contract as #sylvia ::types::ContractApi> :: #enum_accessor ::response_schemas_impl()});
 
         let response_schemas = match msg_ty {
             MsgType::Query => {
                 quote! {
                     #[cfg(not(target_arch = "wasm32"))]
-                    impl #bracketed_wrapper_generics #sylvia ::cw_schema::QueryResponses for #contract_enum_name #bracketed_wrapper_generics #wrapper_where_clause {
+                    impl #bracketed_wrapper_generics #sylvia ::cw_schema::QueryResponses for #contract_enum_name #bracketed_wrapper_generics #full_where_clause {
                         fn response_schemas_impl() -> std::collections::BTreeMap<String, #sylvia ::schemars::schema::RootSchema> {
                             let responses = [#(#response_schemas_calls),*];
                             responses.into_iter().flatten().collect()
@@ -944,15 +913,55 @@ impl<'a> GlueMessage<'a> {
 
         quote! {
             #[allow(clippy::derive_partial_eq_without_eq)]
-            #[derive(#sylvia ::serde::Serialize, Clone, Debug, PartialEq, #sylvia ::schemars::JsonSchema)]
+            #[derive(#sylvia ::serde::Serialize, Clone, Debug, PartialEq)]
             #[serde(rename_all="snake_case", untagged)]
-            pub enum #contract_enum_name #bracketed_wrapper_generics #wrapper_where_clause {
+            pub enum #contract_enum_name #bracketed_wrapper_generics #full_where_clause {
                 #(#variants,)*
                 #contract_variant
             }
 
-            impl #bracketed_wrapper_generics #contract_enum_name #bracketed_wrapper_generics #wrapper_where_clause {
-                pub fn dispatch #unused_generics (
+            // `schemars` v0.8.16 requires every generic type to implement JsonSchema in
+            // order to use derive JsonSchema macro. The goal of that trait bound is to
+            // generate schema_name. Currently there's no way to provide such a name in an
+            // attribute, so Sylvia needs to implement this trait manually:
+            //
+            impl #bracketed_wrapper_generics #sylvia ::schemars::JsonSchema
+                for #contract_enum_name #bracketed_wrapper_generics #full_where_clause {
+
+                fn schema_name() -> std::string::String {
+                    {
+                        let res = format!(
+                                "{0}",
+                                std::any::type_name::<Self>()
+                        );
+                        res
+                    }
+                }
+
+                fn json_schema(
+                    gen: &mut #sylvia ::schemars::gen::SchemaGenerator,
+                ) -> #sylvia ::schemars::schema::Schema {
+                    schemars::schema::Schema::Object(schemars::schema::SchemaObject {
+                        subschemas: Some(
+                            Box::new(schemars::schema::SubschemaValidation {
+                                any_of: Some(
+                                    <[_]>::into_vec(
+                                        Box::new([
+                                            #(gen.subschema_for::<#types>(),)*
+                                            gen.subschema_for::< <#contract as #sylvia ::types::ContractApi> :: #enum_accessor >(),
+                                        ]),
+                                    ),
+                                ),
+                                ..Default::default()
+                            }),
+                        ),
+                        ..Default::default()
+                    })
+                }
+            }
+
+            impl #bracketed_wrapper_generics #contract_enum_name #bracketed_wrapper_generics #full_where_clause {
+                pub fn dispatch (
                     self,
                     contract: &#contract,
                     ctx: #ctx_type,
@@ -971,9 +980,9 @@ impl<'a> GlueMessage<'a> {
 
             #response_schemas
 
-            impl<'de, #(#wrapper_generics,)* > serde::Deserialize<'de> for #contract_enum_name #bracketed_wrapper_generics #wrapper_where_clause {
+            impl<'sv_deserializde_lifetime, #(#generics,)* > serde::Deserialize<'sv_deserializde_lifetime> for #contract_enum_name #bracketed_wrapper_generics #full_where_clause {
                 fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-                    where D: serde::Deserializer<'de>,
+                    where D: serde::Deserializer<'sv_deserializde_lifetime>,
                 {
                     use serde::de::Error;
 
@@ -1021,16 +1030,10 @@ pub struct ContractApi<'a> {
     sudo_variants: MsgVariants<'a, GenericParam>,
     generics: &'a [&'a GenericParam],
     custom: &'a Custom,
-    interfaces: &'a Interfaces,
 }
 
 impl<'a> ContractApi<'a> {
-    pub fn new(
-        source: &'a ItemImpl,
-        generics: &'a [&'a GenericParam],
-        custom: &'a Custom,
-        interfaces: &'a Interfaces,
-    ) -> Self {
+    pub fn new(source: &'a ItemImpl, generics: &'a [&'a GenericParam], custom: &'a Custom) -> Self {
         let exec_variants = MsgVariants::new(
             source.as_variants(),
             MsgType::Exec,
@@ -1075,7 +1078,6 @@ impl<'a> ContractApi<'a> {
             sudo_variants,
             generics,
             custom,
-            interfaces,
         }
     }
 
@@ -1090,7 +1092,7 @@ impl<'a> ContractApi<'a> {
             sudo_variants,
             generics,
             custom,
-            interfaces,
+            ..
         } = self;
 
         let where_clause = &source.generics.where_clause;
@@ -1101,34 +1103,12 @@ impl<'a> ContractApi<'a> {
         let migrate_generics = &migrate_variants.used_generics;
         let sudo_generics = &sudo_variants.used_generics;
 
-        let interface_generics = interfaces.as_generic_args();
-        let interface_generics = filter_generics(generics, &interface_generics);
-
-        let contract_exec_generics: Vec<_> = interface_generics
-            .iter()
-            .chain(exec_generics.iter())
-            .unique()
-            .collect();
-        let contract_query_generics: Vec<_> = interface_generics
-            .iter()
-            .chain(query_generics.iter())
-            .unique()
-            .collect();
-        let contract_sudo_generics: Vec<_> = interface_generics
-            .iter()
-            .chain(sudo_generics.iter())
-            .unique()
-            .collect();
-
         let bracket_generics = emit_bracketed_generics(generics);
         let exec_bracketed_generics = emit_bracketed_generics(exec_generics);
         let query_bracketed_generics = emit_bracketed_generics(query_generics);
         let sudo_bracketed_generics = emit_bracketed_generics(sudo_generics);
         let instantiate_bracketed_generics = emit_bracketed_generics(instantiate_generics);
         let migrate_bracketed_generics = emit_bracketed_generics(migrate_generics);
-        let contract_exec_bracketed_generics = emit_bracketed_generics(&contract_exec_generics);
-        let contract_query_bracketed_generics = emit_bracketed_generics(&contract_query_generics);
-        let contract_sudo_bracketed_generics = emit_bracketed_generics(&contract_sudo_generics);
 
         let migrate_type = if migrate_variants.variants().count() != 0 {
             quote! { type Migrate = MigrateMsg #migrate_bracketed_generics; }
@@ -1139,9 +1119,9 @@ impl<'a> ContractApi<'a> {
 
         quote! {
             impl #bracket_generics #sylvia ::types::ContractApi for #contract_name #where_clause {
-                type ContractExec = ContractExecMsg #contract_exec_bracketed_generics;
-                type ContractQuery = ContractQueryMsg #contract_query_bracketed_generics;
-                type ContractSudo = ContractSudoMsg #contract_sudo_bracketed_generics;
+                type ContractExec = ContractExecMsg #bracket_generics;
+                type ContractQuery = ContractQueryMsg #bracket_generics;
+                type ContractSudo = ContractSudoMsg #bracket_generics;
                 type Exec = ExecMsg #exec_bracketed_generics;
                 type Query = QueryMsg #query_bracketed_generics;
                 type Sudo = SudoMsg #sudo_bracketed_generics;
@@ -1181,6 +1161,7 @@ impl<'a> InterfaceApi<'a> {
             associated_types,
         } = self;
 
+        let interface_name = &source.ident;
         let generics: Vec<_> = associated_types
             .without_special()
             .map(ItemType::as_name)
@@ -1210,11 +1191,6 @@ impl<'a> InterfaceApi<'a> {
         let query_generics = &query_variants.used_generics;
         let sudo_generics = &sudo_variants.used_generics;
 
-        let bracket_generics = emit_bracketed_generics(&generics);
-        let exec_bracketed_generics = emit_bracketed_generics(exec_generics);
-        let query_bracketed_generics = emit_bracketed_generics(query_generics);
-        let sudo_bracketed_generics = emit_bracketed_generics(sudo_generics);
-
         let phantom = if !generics.is_empty() {
             quote! {
                 _phantom: std::marker::PhantomData<( #(#generics,)* )>,
@@ -1224,14 +1200,29 @@ impl<'a> InterfaceApi<'a> {
         };
 
         quote! {
-            pub struct Api #bracket_generics {
+            pub trait InterfaceMessagesApi {
+                type Exec;
+                type Query;
+                type Sudo;
+                type Querier<'querier>;
+            }
+
+            impl<Contract: #interface_name> InterfaceMessagesApi for Contract {
+                type Exec = ExecMsg < #(<Contract as #interface_name >:: #exec_generics,)* >;
+                type Query = QueryMsg < #(<Contract as #interface_name >:: #query_generics,)* >;
+                type Sudo = SudoMsg < #(<Contract as #interface_name >:: #sudo_generics ,)* >;
+                type Querier<'querier> = #sylvia ::types::BoundQuerier<'querier, #custom_query, Contract >;
+            }
+
+
+            pub struct Api < #(#generics,)* > {
                 #phantom
             }
 
-            impl #bracket_generics #sylvia ::types::InterfaceApi for Api #bracket_generics #where_clause {
-                type Exec = ExecMsg #exec_bracketed_generics;
-                type Query = QueryMsg #query_bracketed_generics;
-                type Sudo = SudoMsg #sudo_bracketed_generics;
+            impl < #(#generics,)* > #sylvia ::types::InterfaceApi for Api < #(#generics,)* > #where_clause {
+                type Exec = ExecMsg < #(#exec_generics,)* >;
+                type Query = QueryMsg < #(#query_generics,)* >;
+                type Sudo = SudoMsg < #(#sudo_generics,)* >;
                 type Querier<'querier, Contract> = #sylvia ::types::BoundQuerier<'querier, #custom_query, Contract >;
             }
         }

--- a/sylvia-derive/src/message.rs
+++ b/sylvia-derive/src/message.rs
@@ -850,10 +850,7 @@ impl<'a> GlueMessage<'a> {
 
         let generics: Vec<_> = source.generics.params.iter().collect();
         let full_where_clause = &source.generics.where_clause;
-        let bracketed_wrapper_generics = match generics.is_empty() {
-            true => quote! {},
-            false => quote! { < #(#generics,)* > },
-        };
+        let bracketed_wrapper_generics = emit_bracketed_generics(&generics);
 
         let contract_enum_name = msg_ty.emit_msg_wrapper_name();
         let enum_accessor = msg_ty.as_accessor_name();
@@ -941,9 +938,9 @@ impl<'a> GlueMessage<'a> {
                 fn json_schema(
                     gen: &mut #sylvia ::schemars::gen::SchemaGenerator,
                 ) -> #sylvia ::schemars::schema::Schema {
-                    schemars::schema::Schema::Object(schemars::schema::SchemaObject {
+                    #sylvia ::schemars::schema::Schema::Object( #sylvia ::schemars::schema::SchemaObject {
                         subschemas: Some(
-                            Box::new(schemars::schema::SubschemaValidation {
+                            Box::new( #sylvia ::schemars::schema::SubschemaValidation {
                                 any_of: Some(
                                     <[_]>::into_vec(
                                         Box::new([
@@ -980,9 +977,9 @@ impl<'a> GlueMessage<'a> {
 
             #response_schemas
 
-            impl<'sv_deserializde_lifetime, #(#generics,)* > serde::Deserialize<'sv_deserializde_lifetime> for #contract_enum_name #bracketed_wrapper_generics #full_where_clause {
+            impl<'sv_de, #(#generics,)* > serde::Deserialize<'sv_de> for #contract_enum_name #bracketed_wrapper_generics #full_where_clause {
                 fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-                    where D: serde::Deserializer<'sv_deserializde_lifetime>,
+                    where D: serde::Deserializer<'sv_de>,
                 {
                     use serde::de::Error;
 

--- a/sylvia-derive/src/parser/attributes/messages.rs
+++ b/sylvia-derive/src/parser/attributes/messages.rs
@@ -105,7 +105,7 @@ impl Parse for ContractMessageAttr {
         if !input.is_empty() {
             emit_error!(input.span(),
                 "Unexpected tokens inside `sv::messages` attribtue.";
-                note = "Maximal supported form of attribute: `#[sv::messages(interface::path<T1, T2> as InterfaceName: custom(msg, query))]`."
+                note = "Maximal supported form of attribute: `#[sv::messages(interface::path as InterfaceName: custom(msg, query))]`."
             )
         }
         Ok(Self {

--- a/sylvia-derive/src/querier.rs
+++ b/sylvia-derive/src/querier.rs
@@ -145,7 +145,7 @@ impl<'a> ContractQuerier<'a> {
                 #(#methods_declaration)*
             }
 
-            impl <'a, C: #sylvia ::cw_std::CustomQuery, #(#generics,)*> Querier #bracketed_generics for #sylvia ::types::BoundQuerier<'a, C, #contract_name > #where_clause {
+            impl <'sv_querier_lifetime, #(#generics,)* C: #sylvia ::cw_std::CustomQuery> Querier #bracketed_generics for #sylvia ::types::BoundQuerier<'sv_querier_lifetime, C, #contract_name > #where_clause {
                 #(#types_implementation)*
 
                 #(#methods_impl)*

--- a/sylvia-derive/src/utils.rs
+++ b/sylvia-derive/src/utils.rs
@@ -5,8 +5,8 @@ use quote::{quote, ToTokens};
 use syn::spanned::Spanned;
 use syn::visit::Visit;
 use syn::{
-    parse_quote, FnArg, GenericArgument, GenericParam, Ident, Path, PathArguments, ReturnType,
-    Signature, Type, WhereClause, WherePredicate,
+    parse_quote, FnArg, GenericArgument, Ident, Path, PathArguments, ReturnType, Signature, Type,
+    WhereClause, WherePredicate,
 };
 
 use crate::check_generics::{CheckGenerics, GetPath};
@@ -34,29 +34,6 @@ pub fn filter_wheres<'a, Generic: GetPath + PartialEq>(
                 .collect()
         })
         .unwrap_or_default()
-}
-
-/// Filters generic arguments, which are a concrete types,
-/// from the generic parameters
-///
-/// f.e.
-/// impl<A, B, C> MyTrait<A, B, D> for MyContract<C>
-///
-/// where generic parameters are `[A, B, C]` and generic arguments are `[A, B, D]`
-/// should return us the `[A, B]`.
-pub fn filter_generics<'a>(
-    generic_params: &'a [&'a GenericParam],
-    generic_args: &'a [&'a GenericArgument],
-) -> Vec<&'a GenericParam> {
-    generic_params
-        .iter()
-        .filter(|param| {
-            generic_args
-                .iter()
-                .any(|arg| param.get_path() == arg.get_path())
-        })
-        .copied()
-        .collect()
 }
 
 pub fn process_fields<'s, Generic>(

--- a/sylvia/tests/api.rs
+++ b/sylvia/tests/api.rs
@@ -89,7 +89,7 @@ mod tests {
             SvCustomMsg
         );
 
-        let _: crate::sv::ContractExecMsg<SvCustomMsg> = <SomeContract<
+        let _: crate::sv::ContractExecMsg<_, _, _, _, _> = <SomeContract<
             SvCustomMsg,
             SvCustomMsg,
             SvCustomMsg,
@@ -99,7 +99,7 @@ mod tests {
             exec
         );
 
-        let _: crate::sv::ContractQueryMsg<SvCustomMsg> = <SomeContract<
+        let _: crate::sv::ContractQueryMsg<_, _, _, _, _> = <SomeContract<
             SvCustomMsg,
             SvCustomMsg,
             SvCustomMsg,

--- a/sylvia/tests/multitest.rs
+++ b/sylvia/tests/multitest.rs
@@ -35,7 +35,7 @@ fn instantiate_with_salt() {
 
     let app = App::default();
 
-    let code_id = sv::mt::CodeId::<Empty, _>::store_code(&app);
+    let code_id = sv::mt::CodeId::<SomeContract<Empty>, _>::store_code(&app);
 
     let _: sylvia::multitest::Proxy<_, SomeContract<Empty>> = code_id
         .instantiate(Empty {})
@@ -48,7 +48,7 @@ fn instantiate_with_salt() {
 fn code_info() {
     let app = App::default();
 
-    let code_id = sv::mt::CodeId::<Empty, _>::store_code(&app);
+    let code_id = sv::mt::CodeId::<SomeContract<Empty>, _>::store_code(&app);
 
     let _: CodeInfoResponse = code_id.code_info().unwrap();
     let _: CodeInfoResponse = app.code_info(code_id.code_id()).unwrap();

--- a/sylvia/tests/querier.rs
+++ b/sylvia/tests/querier.rs
@@ -95,7 +95,7 @@ pub struct CounterContract<'a> {
 
 #[contract]
 #[sv::messages(counter)]
-impl CounterContract<'_> {
+impl<'asdf> CounterContract<'asdf> {
     #[allow(clippy::new_without_default)]
     pub fn new() -> Self {
         Self {

--- a/sylvia/tests/ui/attributes/messages/unexpected_token.stderr
+++ b/sylvia/tests/ui/attributes/messages/unexpected_token.stderr
@@ -1,6 +1,6 @@
 error: Unexpected tokens inside `sv::messages` attribtue.
 
-         = note: Maximal supported form of attribute: `#[sv::messages(interface::path<T1, T2> as InterfaceName: custom(msg, query))]`.
+         = note: Maximal supported form of attribute: `#[sv::messages(interface::path as InterfaceName: custom(msg, query))]`.
 
   --> tests/ui/attributes/messages/unexpected_token.rs:24:25
    |


### PR DESCRIPTION
TODO:
* [x] JsonSchema implementation for contract's Exec, Query and Sudo message enums
* [x] Improve sylvia generated code's lifetimes names to avoid collisions