### PR TITLE
Generic interfaces on examples

### DIFF
--- a/examples/contracts/custom/src/cw1.rs
+++ b/examples/contracts/custom/src/cw1.rs
@@ -1,4 +1,4 @@
-use cosmwasm_std::{CosmosMsg, Response, StdError, StdResult};
+use cosmwasm_std::{CosmosMsg, Empty, Response, StdError, StdResult};
 use cw1::{CanExecuteResp, Cw1};
 use sylvia::types::{ExecCtx, QueryCtx};
 
@@ -6,6 +6,9 @@ use crate::contract::CustomContract;
 
 impl Cw1 for CustomContract {
     type Error = StdError;
+    type ExecC = Empty;
+    type QueryC = Empty;
+    type CosmosCustomMsg = Empty;
 
     fn execute(&self, _ctx: ExecCtx, _msgs: Vec<CosmosMsg>) -> StdResult<Response> {
         Ok(Response::new())

--- a/examples/contracts/cw1-subkeys/src/cw1.rs
+++ b/examples/contracts/cw1-subkeys/src/cw1.rs
@@ -1,4 +1,4 @@
-use cosmwasm_std::{ensure, Addr, Response, StdResult};
+use cosmwasm_std::{ensure, Addr, Empty, Response, StdResult};
 use cw1::{CanExecuteResp, Cw1};
 use sylvia::types::{ExecCtx, QueryCtx};
 
@@ -7,6 +7,9 @@ use crate::error::ContractError;
 
 impl Cw1 for Cw1SubkeysContract {
     type Error = ContractError;
+    type ExecC = Empty;
+    type QueryC = Empty;
+    type CosmosCustomMsg = Empty;
 
     fn execute(
         &self,

--- a/examples/contracts/cw1-subkeys/src/whitelist.rs
+++ b/examples/contracts/cw1-subkeys/src/whitelist.rs
@@ -1,4 +1,4 @@
-use cosmwasm_std::{Response, StdResult};
+use cosmwasm_std::{Empty, Response, StdResult};
 use sylvia::types::{ExecCtx, QueryCtx};
 use whitelist::responses::AdminListResponse;
 use whitelist::Whitelist;
@@ -8,6 +8,8 @@ use crate::error::ContractError;
 
 impl Whitelist for Cw1SubkeysContract {
     type Error = ContractError;
+    type ExecC = Empty;
+    type QueryC = Empty;
 
     fn freeze(&self, ctx: ExecCtx) -> Result<Response, Self::Error> {
         self.whitelist.freeze(ctx).map_err(From::from)

--- a/examples/contracts/cw1-whitelist/src/cw1.rs
+++ b/examples/contracts/cw1-whitelist/src/cw1.rs
@@ -1,4 +1,4 @@
-use cosmwasm_std::{Addr, CosmosMsg, Response, StdResult};
+use cosmwasm_std::{Addr, CosmosMsg, Empty, Response, StdResult};
 use cw1::{CanExecuteResp, Cw1};
 use sylvia::types::{ExecCtx, QueryCtx};
 
@@ -7,6 +7,9 @@ use crate::error::ContractError;
 
 impl Cw1 for Cw1WhitelistContract {
     type Error = ContractError;
+    type ExecC = Empty;
+    type QueryC = Empty;
+    type CosmosCustomMsg = Empty;
 
     fn execute(&self, ctx: ExecCtx, msgs: Vec<CosmosMsg>) -> Result<Response, ContractError> {
         if !self.is_admin(ctx.deps.as_ref(), &ctx.info.sender) {

--- a/examples/contracts/cw1-whitelist/src/whitelist.rs
+++ b/examples/contracts/cw1-whitelist/src/whitelist.rs
@@ -8,6 +8,8 @@ use crate::error::ContractError;
 
 impl Whitelist for Cw1WhitelistContract {
     type Error = ContractError;
+    type ExecC = Empty;
+    type QueryC = Empty;
 
     fn freeze(&self, ctx: ExecCtx) -> Result<Response, ContractError> {
         if !self.is_admin(ctx.deps.as_ref(), &ctx.info.sender) {

--- a/examples/contracts/cw20-base/src/allowances.rs
+++ b/examples/contracts/cw20-base/src/allowances.rs
@@ -1,4 +1,4 @@
-use cosmwasm_std::{Addr, Binary, Order, Response, StdError, StdResult, Uint128};
+use cosmwasm_std::{Addr, Binary, Empty, Order, Response, StdError, StdResult, Uint128};
 use cw20_allowances::responses::{
     AllAccountsResponse, AllAllowancesResponse, AllSpenderAllowancesResponse, AllowanceInfo,
     AllowanceResponse, SpenderAllowanceInfo,
@@ -18,6 +18,8 @@ const DEFAULT_LIMIT: u32 = 10;
 
 impl Cw20Allowances for Cw20Base {
     type Error = ContractError;
+    type ExecC = Empty;
+    type QueryC = Empty;
 
     /// Allows spender to access an additional amount tokens from the owner's (env.sender) account.
     /// If expires is Some(), overwrites current allowance expiration with this one.

--- a/examples/contracts/cw20-base/src/marketing.rs
+++ b/examples/contracts/cw20-base/src/marketing.rs
@@ -1,13 +1,15 @@
 use crate::contract::Cw20Base;
 use crate::error::ContractError;
 use crate::validation::verify_logo;
-use cosmwasm_std::{Response, StdError, StdResult};
+use cosmwasm_std::{Empty, Response, StdError, StdResult};
 use cw20_marketing::responses::{DownloadLogoResponse, LogoInfo, MarketingInfoResponse};
 use cw20_marketing::{Cw20Marketing, EmbeddedLogo, Logo};
 use sylvia::types::{ExecCtx, QueryCtx};
 
 impl Cw20Marketing for Cw20Base {
     type Error = ContractError;
+    type ExecC = Empty;
+    type QueryC = Empty;
 
     fn update_marketing(
         &self,

--- a/examples/contracts/cw20-base/src/minting.rs
+++ b/examples/contracts/cw20-base/src/minting.rs
@@ -1,12 +1,14 @@
 use crate::contract::{Cw20Base, MinterData};
 use crate::error::ContractError;
-use cosmwasm_std::{Response, StdResult, Uint128};
+use cosmwasm_std::{Empty, Response, StdResult, Uint128};
 use cw20_minting::responses::MinterResponse;
 use cw20_minting::Cw20Minting;
 use sylvia::types::{ExecCtx, QueryCtx};
 
 impl Cw20Minting for Cw20Base {
     type Error = ContractError;
+    type ExecC = Empty;
+    type QueryC = Empty;
 
     fn mint(
         &self,

--- a/examples/contracts/generic_contract/src/cw1.rs
+++ b/examples/contracts/generic_contract/src/cw1.rs
@@ -1,5 +1,5 @@
 use crate::contract::GenericContract;
-use cosmwasm_std::{CosmosMsg, Response, StdError, StdResult};
+use cosmwasm_std::{CosmosMsg, Empty, Response, StdError, StdResult};
 use cw1::{CanExecuteResp, Cw1};
 use sylvia::types::{ExecCtx, QueryCtx};
 
@@ -33,6 +33,9 @@ impl<
     >
 {
     type Error = StdError;
+    type ExecC = Empty;
+    type QueryC = Empty;
+    type CosmosCustomMsg = Empty;
 
     fn execute(&self, _ctx: ExecCtx, _msgs: Vec<CosmosMsg>) -> StdResult<Response> {
         Ok(Response::new())

--- a/examples/contracts/generic_iface_on_contract/src/cw1.rs
+++ b/examples/contracts/generic_iface_on_contract/src/cw1.rs
@@ -1,9 +1,12 @@
-use cosmwasm_std::{CosmosMsg, Response, StdError, StdResult};
+use cosmwasm_std::{CosmosMsg, Empty, Response, StdError, StdResult};
 use cw1::{CanExecuteResp, Cw1};
 use sylvia::types::{ExecCtx, QueryCtx};
 
 impl Cw1 for crate::contract::NonGenericContract {
     type Error = StdError;
+    type ExecC = Empty;
+    type QueryC = Empty;
+    type CosmosCustomMsg = Empty;
 
     fn execute(&self, _ctx: ExecCtx, _msgs: Vec<CosmosMsg>) -> StdResult<Response> {
         Ok(Response::new())

--- a/examples/contracts/generics_forwarded/src/cw1.rs
+++ b/examples/contracts/generics_forwarded/src/cw1.rs
@@ -1,5 +1,5 @@
 use cosmwasm_schema::schemars::JsonSchema;
-use cosmwasm_std::{CosmosMsg, CustomMsg, Response, StdResult};
+use cosmwasm_std::{CosmosMsg, CustomMsg, Empty, Response, StdResult};
 use cw1::{CanExecuteResp, Cw1};
 use serde::de::DeserializeOwned;
 use serde::Deserialize;
@@ -57,6 +57,9 @@ where
     FieldT: 'static,
 {
     type Error = ContractError;
+    type ExecC = Empty;
+    type QueryC = Empty;
+    type CosmosCustomMsg = Empty;
 
     fn execute(&self, _ctx: ExecCtx, _msgs: Vec<CosmosMsg>) -> Result<Response, Self::Error> {
         Ok(Response::new())

--- a/examples/interfaces/cw1/src/lib.rs
+++ b/examples/interfaces/cw1/src/lib.rs
@@ -41,11 +41,13 @@ pub trait Cw1 {
 
 #[cfg(test)]
 mod tests {
-    use cosmwasm_std::{coins, from_json, to_json_binary, BankMsg};
+    use cosmwasm_std::{coins, from_json, to_json_binary, BankMsg, Empty};
+
+    use crate::sv::{Cw1ExecMsg, Cw1QueryMsg};
 
     #[test]
     fn execute() {
-        let original = super::sv::ExecMsg::Execute {
+        let original: Cw1ExecMsg<Empty> = super::sv::ExecMsg::Execute {
             msgs: vec![BankMsg::Send {
                 to_address: "receiver".to_owned(),
                 amount: coins(10, "atom"),
@@ -61,13 +63,13 @@ mod tests {
 
     #[test]
     fn execute_from_json() {
-        let deserialized = from_json(br#"{"execute": { "msgs": [] }}"#).unwrap();
+        let deserialized: Cw1ExecMsg<Empty> = from_json(br#"{"execute": { "msgs": [] }}"#).unwrap();
         assert_eq!(super::sv::ExecMsg::Execute { msgs: vec![] }, deserialized);
     }
 
     #[test]
     fn query() {
-        let original = super::sv::QueryMsg::CanExecute {
+        let original: Cw1QueryMsg<Empty> = super::sv::QueryMsg::CanExecute {
             sender: "sender".to_owned(),
             msg: BankMsg::Send {
                 to_address: "receiver".to_owned(),
@@ -84,7 +86,7 @@ mod tests {
 
     #[test]
     fn query_from_json() {
-        let deserialized = from_json(
+        let deserialized: Cw1QueryMsg<Empty> = from_json(
             br#"{"can_execute": {
                 "sender": "address",
                 "msg": {

--- a/examples/interfaces/cw20-allowances/src/lib.rs
+++ b/examples/interfaces/cw20-allowances/src/lib.rs
@@ -5,73 +5,74 @@ use cw_utils::Expiration;
 use responses::{
     AllAccountsResponse, AllAllowancesResponse, AllSpenderAllowancesResponse, AllowanceResponse,
 };
-use sylvia::types::{ExecCtx, QueryCtx};
+use sylvia::types::{CustomMsg, CustomQuery, ExecCtx, QueryCtx};
 use sylvia::{interface, schemars};
 
 #[interface]
-#[sv::custom(msg=cosmwasm_std::Empty, query=cosmwasm_std::Empty)]
 pub trait Cw20Allowances {
     type Error: From<StdError>;
+    type ExecC: CustomMsg;
+    type QueryC: CustomQuery;
 
     /// Allows spender to access an additional amount tokens from the owner's (env.sender) account.
     /// If expires is Some(), overwrites current allowance expiration with this one.
     #[sv::msg(exec)]
     fn increase_allowance(
         &self,
-        ctx: ExecCtx,
+        ctx: ExecCtx<Self::QueryC>,
         spender: String,
         amount: Uint128,
         expires: Option<Expiration>,
-    ) -> Result<Response, Self::Error>;
+    ) -> Result<Response<Self::ExecC>, Self::Error>;
 
     /// Lowers the spender's access of tokens from the owner's (env.sender) account by amount.
     /// If expires is Some(), overwrites current allowance expiration with this one.
     #[sv::msg(exec)]
     fn decrease_allowance(
         &self,
-        ctx: ExecCtx,
+        ctx: ExecCtx<Self::QueryC>,
         spender: String,
         amount: Uint128,
         expires: Option<Expiration>,
-    ) -> Result<Response, Self::Error>;
+    ) -> Result<Response<Self::ExecC>, Self::Error>;
 
     /// Transfers amount tokens from owner -> recipient
     /// if `env.sender` has sufficient pre-approval.
     #[sv::msg(exec)]
     fn transfer_from(
         &self,
-        ctx: ExecCtx,
+        ctx: ExecCtx<Self::QueryC>,
         owner: String,
         recipient: String,
         amount: Uint128,
-    ) -> Result<Response, Self::Error>;
+    ) -> Result<Response<Self::ExecC>, Self::Error>;
 
     /// Sends amount tokens from owner -> contract
     /// if `env.sender` has sufficient pre-approval.
     #[sv::msg(exec)]
     fn send_from(
         &self,
-        ctx: ExecCtx,
+        ctx: ExecCtx<Self::QueryC>,
         owner: String,
         contract: String,
         amount: Uint128,
         msg: Binary,
-    ) -> Result<Response, Self::Error>;
+    ) -> Result<Response<Self::ExecC>, Self::Error>;
 
     /// Destroys amount of tokens forever
     #[sv::msg(exec)]
     fn burn_from(
         &self,
-        ctx: ExecCtx,
+        ctx: ExecCtx<Self::QueryC>,
         owner: String,
         amount: Uint128,
-    ) -> Result<Response, Self::Error>;
+    ) -> Result<Response<Self::ExecC>, Self::Error>;
 
     /// Returns how much spender can use from owner account, 0 if unset.
     #[sv::msg(query)]
     fn allowance(
         &self,
-        ctx: QueryCtx,
+        ctx: QueryCtx<Self::QueryC>,
         owner: String,
         spender: String,
     ) -> StdResult<AllowanceResponse>;
@@ -80,7 +81,7 @@ pub trait Cw20Allowances {
     #[sv::msg(query)]
     fn all_allowances(
         &self,
-        ctx: QueryCtx,
+        ctx: QueryCtx<Self::QueryC>,
         owner: String,
         start_after: Option<String>,
         limit: Option<u32>,
@@ -90,7 +91,7 @@ pub trait Cw20Allowances {
     #[sv::msg(query)]
     fn all_spender_allowances(
         &self,
-        ctx: QueryCtx,
+        ctx: QueryCtx<Self::QueryC>,
         spender: String,
         start_after: Option<String>,
         limit: Option<u32>,
@@ -100,7 +101,7 @@ pub trait Cw20Allowances {
     #[sv::msg(query)]
     fn all_accounts(
         &self,
-        ctx: QueryCtx,
+        ctx: QueryCtx<Self::QueryC>,
         start_after: Option<String>,
         limit: Option<u32>,
     ) -> StdResult<AllAccountsResponse>;

--- a/examples/interfaces/cw20-minting/src/lib.rs
+++ b/examples/interfaces/cw20-minting/src/lib.rs
@@ -2,33 +2,34 @@ pub mod responses;
 
 use cosmwasm_std::{Response, StdError, StdResult, Uint128};
 use responses::MinterResponse;
-use sylvia::types::{ExecCtx, QueryCtx};
+use sylvia::types::{CustomMsg, CustomQuery, ExecCtx, QueryCtx};
 use sylvia::{interface, schemars};
 
 #[interface]
-#[sv::custom(msg=cosmwasm_std::Empty, query=cosmwasm_std::Empty)]
 pub trait Cw20Minting {
     type Error: From<StdError>;
+    type ExecC: CustomMsg;
+    type QueryC: CustomQuery;
 
     /// If authorized, creates amount new tokens and adds to the recipient balance.
     #[sv::msg(exec)]
     fn mint(
         &self,
-        ctx: ExecCtx,
+        ctx: ExecCtx<Self::QueryC>,
         recipient: String,
         amount: Uint128,
-    ) -> Result<Response, Self::Error>;
+    ) -> Result<Response<Self::ExecC>, Self::Error>;
 
     /// The current minter may set a new minter.
     /// Setting the minter to None will remove the token's minter forever.
     #[sv::msg(exec)]
     fn update_minter(
         &self,
-        ctx: ExecCtx,
+        ctx: ExecCtx<Self::QueryC>,
         new_minter: Option<String>,
-    ) -> Result<Response, Self::Error>;
+    ) -> Result<Response<Self::ExecC>, Self::Error>;
 
     /// Returns who can mint and the hard cap on maximum tokens after minting.
     #[sv::msg(query)]
-    fn minter(&self, ctx: QueryCtx) -> StdResult<Option<MinterResponse>>;
+    fn minter(&self, ctx: QueryCtx<Self::QueryC>) -> StdResult<Option<MinterResponse>>;
 }

--- a/examples/interfaces/cw4/src/lib.rs
+++ b/examples/interfaces/cw4/src/lib.rs
@@ -1,39 +1,76 @@
 use cosmwasm_std::{Response, StdError};
-
-use sylvia::types::{ExecCtx, QueryCtx};
+use sylvia::types::{CustomMsg, CustomQuery, ExecCtx, QueryCtx};
 use sylvia::{interface, schemars};
 
 #[interface]
-#[sv::custom(msg=cosmwasm_std::Empty, query=cosmwasm_std::Empty)]
 pub trait Cw4 {
     type Error: From<StdError>;
+    type ExecC: CustomMsg;
+    type QueryC: CustomQuery;
+    type MemberCustomMsg: CustomMsg;
+    type ListMembersCustomMsg: CustomMsg;
+    type TotalWeightCustomMsg: CustomMsg;
+    type AdminCustomMsg: CustomMsg;
+    type HooksCustomMsg: CustomMsg;
 
     #[sv::msg(exec)]
-    fn update_admin(&self, ctx: ExecCtx, admin: String) -> Result<Response, Self::Error>;
+    fn update_admin(
+        &self,
+        ctx: ExecCtx<Self::QueryC>,
+        admin: String,
+    ) -> Result<Response<Self::ExecC>, Self::Error>;
 
     #[sv::msg(exec)]
-    fn update_members(&self, ctx: ExecCtx, members: Vec<String>) -> Result<Response, Self::Error>;
+    fn update_members(
+        &self,
+        ctx: ExecCtx<Self::QueryC>,
+        members: Vec<String>,
+    ) -> Result<Response<Self::ExecC>, Self::Error>;
 
     #[sv::msg(exec)]
-    fn add_hook(&self, ctx: ExecCtx, hook: String) -> Result<Response, Self::Error>;
+    fn add_hook(
+        &self,
+        ctx: ExecCtx<Self::QueryC>,
+        hook: String,
+    ) -> Result<Response<Self::ExecC>, Self::Error>;
 
     #[sv::msg(exec)]
-    fn remove_hook(&self, ctx: ExecCtx, hook: String) -> Result<Response, Self::Error>;
+    fn remove_hook(
+        &self,
+        ctx: ExecCtx<Self::QueryC>,
+        hook: String,
+    ) -> Result<Response<Self::ExecC>, Self::Error>;
 
     #[sv::msg(query)]
-    fn member(&self, ctx: QueryCtx, member: String) -> Result<Response, Self::Error>;
+    fn member(
+        &self,
+        ctx: QueryCtx<Self::QueryC>,
+        member: String,
+    ) -> Result<Response<Self::MemberCustomMsg>, Self::Error>;
 
     #[sv::msg(query)]
-    fn list_members(&self, ctx: QueryCtx) -> Result<Response, Self::Error>;
+    fn list_members(
+        &self,
+        ctx: QueryCtx<Self::QueryC>,
+    ) -> Result<Response<Self::ListMembersCustomMsg>, Self::Error>;
 
     #[sv::msg(query)]
-    fn total_weight(&self, ctx: QueryCtx) -> Result<Response, Self::Error>;
+    fn total_weight(
+        &self,
+        ctx: QueryCtx<Self::QueryC>,
+    ) -> Result<Response<Self::TotalWeightCustomMsg>, Self::Error>;
 
     #[sv::msg(query)]
-    fn admin(&self, ctx: QueryCtx) -> Result<Response, Self::Error>;
+    fn admin(
+        &self,
+        ctx: QueryCtx<Self::QueryC>,
+    ) -> Result<Response<Self::AdminCustomMsg>, Self::Error>;
 
     #[sv::msg(query)]
-    fn hooks(&self, ctx: QueryCtx) -> Result<Response, Self::Error>;
+    fn hooks(
+        &self,
+        ctx: QueryCtx<Self::QueryC>,
+    ) -> Result<Response<Self::HooksCustomMsg>, Self::Error>;
 }
 
 #[cfg(test)]

--- a/examples/interfaces/cw4/src/lib.rs
+++ b/examples/interfaces/cw4/src/lib.rs
@@ -75,7 +75,7 @@ pub trait Cw4 {
 
 #[cfg(test)]
 mod tests {
-    use cosmwasm_std::{from_json, to_json_binary};
+    use cosmwasm_std::{from_json, to_json_binary, Empty};
 
     use super::sv::*;
 
@@ -96,7 +96,8 @@ mod tests {
         let original_msg = Cw4QueryMsg::Admin {};
 
         let serialized_msg = to_json_binary(&original_msg).unwrap();
-        let serialized_msg: Cw4QueryMsg = from_json(serialized_msg).unwrap();
+        let serialized_msg: Cw4QueryMsg<Empty, Empty, Empty, Empty, Empty> =
+            from_json(serialized_msg).unwrap();
 
         assert_eq!(serialized_msg, original_msg);
     }
@@ -115,7 +116,8 @@ mod tests {
 
     #[test]
     fn query_from_json() {
-        let deserialized: Cw4QueryMsg = from_json(br#"{"admin": {}}"#).unwrap();
+        let deserialized: Cw4QueryMsg<Empty, Empty, Empty, Empty, Empty> =
+            from_json(br#"{"admin": {}}"#).unwrap();
         assert_eq!(deserialized, Cw4QueryMsg::Admin {});
     }
 

--- a/examples/interfaces/cw4/src/lib.rs
+++ b/examples/interfaces/cw4/src/lib.rs
@@ -1,4 +1,9 @@
+pub mod responses;
+
 use cosmwasm_std::{Response, StdError};
+use responses::{
+    AdminResponse, HooksResponse, MemberListResponse, MemberResponse, TotalWeightResponse,
+};
 use sylvia::types::{CustomMsg, CustomQuery, ExecCtx, QueryCtx};
 use sylvia::{interface, schemars};
 
@@ -7,11 +12,6 @@ pub trait Cw4 {
     type Error: From<StdError>;
     type ExecC: CustomMsg;
     type QueryC: CustomQuery;
-    type MemberCustomMsg: CustomMsg;
-    type ListMembersCustomMsg: CustomMsg;
-    type TotalWeightCustomMsg: CustomMsg;
-    type AdminCustomMsg: CustomMsg;
-    type HooksCustomMsg: CustomMsg;
 
     #[sv::msg(exec)]
     fn update_admin(
@@ -46,36 +46,30 @@ pub trait Cw4 {
         &self,
         ctx: QueryCtx<Self::QueryC>,
         member: String,
-    ) -> Result<Response<Self::MemberCustomMsg>, Self::Error>;
+    ) -> Result<Response<MemberResponse>, Self::Error>;
 
     #[sv::msg(query)]
     fn list_members(
         &self,
         ctx: QueryCtx<Self::QueryC>,
-    ) -> Result<Response<Self::ListMembersCustomMsg>, Self::Error>;
+    ) -> Result<Response<MemberListResponse>, Self::Error>;
 
     #[sv::msg(query)]
     fn total_weight(
         &self,
         ctx: QueryCtx<Self::QueryC>,
-    ) -> Result<Response<Self::TotalWeightCustomMsg>, Self::Error>;
+    ) -> Result<Response<TotalWeightResponse>, Self::Error>;
 
     #[sv::msg(query)]
-    fn admin(
-        &self,
-        ctx: QueryCtx<Self::QueryC>,
-    ) -> Result<Response<Self::AdminCustomMsg>, Self::Error>;
+    fn admin(&self, ctx: QueryCtx<Self::QueryC>) -> Result<Response<AdminResponse>, Self::Error>;
 
     #[sv::msg(query)]
-    fn hooks(
-        &self,
-        ctx: QueryCtx<Self::QueryC>,
-    ) -> Result<Response<Self::HooksCustomMsg>, Self::Error>;
+    fn hooks(&self, ctx: QueryCtx<Self::QueryC>) -> Result<Response<HooksResponse>, Self::Error>;
 }
 
 #[cfg(test)]
 mod tests {
-    use cosmwasm_std::{from_json, to_json_binary, Empty};
+    use cosmwasm_std::{from_json, to_json_binary};
 
     use super::sv::*;
 
@@ -96,8 +90,7 @@ mod tests {
         let original_msg = Cw4QueryMsg::Admin {};
 
         let serialized_msg = to_json_binary(&original_msg).unwrap();
-        let serialized_msg: Cw4QueryMsg<Empty, Empty, Empty, Empty, Empty> =
-            from_json(serialized_msg).unwrap();
+        let serialized_msg: Cw4QueryMsg = from_json(serialized_msg).unwrap();
 
         assert_eq!(serialized_msg, original_msg);
     }
@@ -116,8 +109,7 @@ mod tests {
 
     #[test]
     fn query_from_json() {
-        let deserialized: Cw4QueryMsg<Empty, Empty, Empty, Empty, Empty> =
-            from_json(br#"{"admin": {}}"#).unwrap();
+        let deserialized: Cw4QueryMsg = from_json(br#"{"admin": {}}"#).unwrap();
         assert_eq!(deserialized, Cw4QueryMsg::Admin {});
     }
 

--- a/examples/interfaces/cw4/src/responses.rs
+++ b/examples/interfaces/cw4/src/responses.rs
@@ -1,0 +1,35 @@
+use cosmwasm_schema::cw_serde;
+
+#[cw_serde]
+pub struct AdminResponse {
+    pub admin: Option<String>,
+}
+
+/// A group member has a weight associated with them.
+/// This may all be equal, or may have meaning in the app that
+/// makes use of the group (eg. voting power)
+#[cw_serde]
+pub struct Member {
+    pub addr: String,
+    pub weight: u64,
+}
+
+#[cw_serde]
+pub struct MemberListResponse {
+    pub members: Vec<Member>,
+}
+
+#[cw_serde]
+pub struct MemberResponse {
+    pub weight: Option<u64>,
+}
+
+#[cw_serde]
+pub struct TotalWeightResponse {
+    pub weight: u64,
+}
+
+#[cw_serde]
+pub struct HooksResponse {
+    pub hooks: Vec<String>,
+}

--- a/examples/interfaces/whitelist/src/lib.rs
+++ b/examples/interfaces/whitelist/src/lib.rs
@@ -1,23 +1,28 @@
-use cosmwasm_std::{Response, StdResult};
+use cosmwasm_std::{Response, StdError, StdResult};
 use responses::AdminListResponse;
-use sylvia::types::{ExecCtx, QueryCtx};
+use sylvia::types::{CustomMsg, CustomQuery, ExecCtx, QueryCtx};
 use sylvia::{interface, schemars};
 
 pub mod responses;
 
 #[interface]
-#[sv::custom(msg=cosmwasm_std::Empty, query=cosmwasm_std::Empty)]
 pub trait Whitelist {
-    type Error: From<cosmwasm_std::StdError>;
+    type Error: From<StdError>;
+    type ExecC: CustomMsg;
+    type QueryC: CustomQuery;
 
     #[sv::msg(exec)]
-    fn freeze(&self, ctx: ExecCtx) -> Result<Response, Self::Error>;
+    fn freeze(&self, ctx: ExecCtx<Self::QueryC>) -> Result<Response<Self::ExecC>, Self::Error>;
 
     #[sv::msg(exec)]
-    fn update_admins(&self, ctx: ExecCtx, admins: Vec<String>) -> Result<Response, Self::Error>;
+    fn update_admins(
+        &self,
+        ctx: ExecCtx<Self::QueryC>,
+        admins: Vec<String>,
+    ) -> Result<Response<Self::ExecC>, Self::Error>;
 
     #[sv::msg(query)]
-    fn admin_list(&self, ctx: QueryCtx) -> StdResult<AdminListResponse>;
+    fn admin_list(&self, ctx: QueryCtx<Self::QueryC>) -> StdResult<AdminListResponse>;
 }
 
 #[cfg(test)]

--- a/examples/interfaces/whitelist/src/responses.rs
+++ b/examples/interfaces/whitelist/src/responses.rs
@@ -9,8 +9,8 @@ pub struct AdminListResponse {
 
 #[cfg(any(test, feature = "test-utils"))]
 impl AdminListResponse {
-    /// Utility function forconverting message to its canonical form, so two messages with
-    /// different representation but same semantical meaning can be easly compared.
+    /// Utility function for converting message to its canonical form, so two messages with
+    /// different representation but same semantical meaning can be easily compared.
     ///
     /// It could be encapsulated in custom `PartialEq` implementation, but `PartialEq` is expected
     /// to be quickly, so it seems to be reasonable to keep it as representation-equality, and


### PR DESCRIPTION
Part of #399.

This PR deals with the "Interfaces" part of the issue above.

It also makes the affected contracts and tests use `cosmwasm_std::Empty` for their different implementations of the now generic interfaces.