### PR TITLE
feat: Error on missing `generics` parameter in `entry_points` macro

### DIFF
--- a/sylvia-derive/src/lib.rs
+++ b/sylvia-derive/src/lib.rs
@@ -29,6 +29,7 @@ mod variant_descs;
 use strip_input::StripInput;
 
 use crate::message::EntryPoints;
+use crate::parser::EntryPointArgs;
 
 #[cfg(not(test))]
 pub(crate) fn crate_module() -> Path {
@@ -757,8 +758,8 @@ pub fn entry_points(attr: TokenStream, item: TokenStream) -> TokenStream {
 
 fn entry_points_impl(attr: TokenStream2, item: TokenStream2) -> TokenStream2 {
     fn inner(attr: TokenStream2, item: TokenStream2) -> syn::Result<TokenStream2> {
-        let attrs: parser::EntryPointArgs = parse2(attr)?;
         let input: ItemImpl = parse2(item)?;
+        let attrs = EntryPointArgs::new(&attr, &input)?;
         let expanded = EntryPoints::new(&input, attrs).emit();
 
         Ok(quote! {

--- a/sylvia/tests/ui/macros/entry_points.rs
+++ b/sylvia/tests/ui/macros/entry_points.rs
@@ -1,0 +1,29 @@
+use sylvia::cw_std::{Response, StdResult};
+use sylvia::types::{CustomMsg, CustomQuery, InstantiateCtx};
+use sylvia::{contract, entry_points};
+
+pub struct Contract<E, Q> {
+    _phantom: std::marker::PhantomData<(E, Q)>,
+}
+
+#[entry_points]
+#[contract]
+#[sv::custom(msg = E, query = Q)]
+impl<E, Q> Contract<E, Q>
+where
+    E: CustomMsg + 'static,
+    Q: CustomQuery + 'static,
+{
+    pub fn new() -> Self {
+        Self {
+            _phantom: std::marker::PhantomData,
+        }
+    }
+
+    #[sv::msg(instantiate)]
+    fn instantiate(&self, _ctx: InstantiateCtx<Q>) -> StdResult<Response<E>> {
+        Ok(Response::new())
+    }
+}
+
+fn main() {}

--- a/sylvia/tests/ui/macros/entry_points.rs
+++ b/sylvia/tests/ui/macros/entry_points.rs
@@ -1,28 +1,62 @@
+#![allow(unused_imports)]
+
 use sylvia::cw_std::{Response, StdResult};
 use sylvia::types::{CustomMsg, CustomQuery, InstantiateCtx};
 use sylvia::{contract, entry_points};
 
-pub struct Contract<E, Q> {
-    _phantom: std::marker::PhantomData<(E, Q)>,
-}
+pub mod no_generics {
+    use super::*;
 
-#[entry_points]
-#[contract]
-#[sv::custom(msg = E, query = Q)]
-impl<E, Q> Contract<E, Q>
-where
-    E: CustomMsg + 'static,
-    Q: CustomQuery + 'static,
-{
-    pub fn new() -> Self {
-        Self {
-            _phantom: std::marker::PhantomData,
-        }
+    pub struct Contract<E, Q> {
+        _phantom: std::marker::PhantomData<(E, Q)>,
     }
 
-    #[sv::msg(instantiate)]
-    fn instantiate(&self, _ctx: InstantiateCtx<Q>) -> StdResult<Response<E>> {
-        Ok(Response::new())
+    #[entry_points]
+    #[contract]
+    #[sv::custom(msg = E, query = Q)]
+    impl<E, Q> Contract<E, Q>
+    where
+        E: CustomMsg + 'static,
+        Q: CustomQuery + 'static,
+    {
+        pub fn new() -> Self {
+            Self {
+                _phantom: std::marker::PhantomData,
+            }
+        }
+
+        #[sv::msg(instantiate)]
+        fn instantiate(&self, _ctx: InstantiateCtx<Q>) -> StdResult<Response<E>> {
+            Ok(Response::new())
+        }
+    }
+}
+
+pub mod missing_generics {
+    use super::*;
+
+    pub struct Contract<E, Q> {
+        _phantom: std::marker::PhantomData<(E, Q)>,
+    }
+
+    #[entry_points(generics<Empty>)]
+    #[contract]
+    #[sv::custom(msg = E, query = Q)]
+    impl<E, Q> Contract<E, Q>
+    where
+        E: CustomMsg + 'static,
+        Q: CustomQuery + 'static,
+    {
+        pub fn new() -> Self {
+            Self {
+                _phantom: std::marker::PhantomData,
+            }
+        }
+
+        #[sv::msg(instantiate)]
+        fn instantiate(&self, _ctx: InstantiateCtx<Q>) -> StdResult<Response<E>> {
+            Ok(Response::new())
+        }
     }
 }
 

--- a/sylvia/tests/ui/macros/entry_points.stderr
+++ b/sylvia/tests/ui/macros/entry_points.stderr
@@ -1,0 +1,19 @@
+error: Missing concrete types.
+
+         = note: For every generic type in the contract, a concrete type must be provided in `#[entry_points(generics<T1, T2, ...>)]`.
+
+  --> tests/ui/macros/entry_points.rs:14:5
+   |
+14 |     #[entry_points]
+   |     ^^^^^^^^^^^^^^^
+   |
+   = note: this error originates in the attribute macro `entry_points` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: Missing concrete types.
+
+         = note: For every generic type in the contract, a concrete type must be provided in `#[entry_points(generics<T1, T2, ...>)]`.
+
+  --> tests/ui/macros/entry_points.rs:42:20
+   |
+42 |     #[entry_points(generics<Empty>)]
+   |                    ^^^^^^^^


### PR DESCRIPTION
Additionally there is some refactor done. Some code could be reused. Also,  `MsgVariants` generated some code it should not.