### PR TITLE
feat: Make cosmwasm_schema deps obsolete

### DIFF
--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -406,7 +406,6 @@ name = "custom"
 version = "0.5.0"
 dependencies = [
  "anyhow",
- "cosmwasm-schema",
  "cw-multi-test",
  "cw-storage-plus",
  "cw1",
@@ -419,7 +418,6 @@ name = "custom-and-generic"
 version = "0.5.0"
 dependencies = [
  "anyhow",
- "cosmwasm-schema",
  "cw-multi-test",
  "serde",
  "sylvia",
@@ -474,7 +472,6 @@ name = "cw1"
 version = "0.5.0"
 dependencies = [
  "anyhow",
- "cosmwasm-schema",
  "cw-multi-test",
  "serde",
  "sylvia",
@@ -485,7 +482,6 @@ name = "cw1-subkeys"
 version = "0.5.0"
 dependencies = [
  "anyhow",
- "cosmwasm-schema",
  "cw-multi-test",
  "cw-storage-plus",
  "cw-utils",
@@ -504,7 +500,6 @@ version = "0.5.0"
 dependencies = [
  "anyhow",
  "assert_matches",
- "cosmwasm-schema",
  "cw-multi-test",
  "cw-storage-plus",
  "cw1",
@@ -535,7 +530,6 @@ name = "cw20-allowances"
 version = "0.5.0"
 dependencies = [
  "anyhow",
- "cosmwasm-schema",
  "cw-multi-test",
  "cw-utils",
  "serde",
@@ -548,7 +542,6 @@ version = "0.5.0"
 dependencies = [
  "anyhow",
  "assert_matches",
- "cosmwasm-schema",
  "cw-multi-test",
  "cw-storage-plus",
  "cw-utils",
@@ -567,7 +560,6 @@ name = "cw20-marketing"
 version = "0.5.0"
 dependencies = [
  "anyhow",
- "cosmwasm-schema",
  "cw-multi-test",
  "serde",
  "sylvia",
@@ -578,7 +570,6 @@ name = "cw20-minting"
 version = "0.5.0"
 dependencies = [
  "anyhow",
- "cosmwasm-schema",
  "cw-multi-test",
  "serde",
  "sylvia",
@@ -589,7 +580,6 @@ name = "cw4"
 version = "0.5.0"
 dependencies = [
  "anyhow",
- "cosmwasm-schema",
  "cw-multi-test",
  "serde",
  "sylvia",
@@ -721,7 +711,6 @@ name = "entry-points-overriding"
 version = "0.5.0"
 dependencies = [
  "anyhow",
- "cosmwasm-schema",
  "cw-multi-test",
  "cw-storage-plus",
  "cw-utils",
@@ -756,7 +745,6 @@ name = "generic"
 version = "0.5.0"
 dependencies = [
  "anyhow",
- "cosmwasm-schema",
  "cw-multi-test",
  "serde",
  "sylvia",
@@ -778,7 +766,6 @@ name = "generic_contract"
 version = "0.5.0"
 dependencies = [
  "anyhow",
- "cosmwasm-schema",
  "custom-and-generic",
  "cw-multi-test",
  "cw-storage-plus",
@@ -794,7 +781,6 @@ name = "generic_iface_on_contract"
 version = "0.5.0"
 dependencies = [
  "anyhow",
- "cosmwasm-schema",
  "custom-and-generic",
  "cw-multi-test",
  "cw-storage-plus",
@@ -810,7 +796,6 @@ name = "generics_forwarded"
 version = "0.5.0"
 dependencies = [
  "anyhow",
- "cosmwasm-schema",
  "custom-and-generic",
  "cw-multi-test",
  "cw-storage-plus",
@@ -1462,7 +1447,6 @@ name = "whitelist"
 version = "0.5.0"
 dependencies = [
  "anyhow",
- "cosmwasm-schema",
  "cw-multi-test",
  "serde",
  "sylvia",

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -28,7 +28,6 @@ edition = "2021"
 
 [workspace.dependencies]
 anyhow = "1.0.86"
-cosmwasm-schema = "2.1.3"
 cw-multi-test = "2.1.1"
 cw-storage-plus = "2.0.0"
 cw-utils = "2.0.0"

--- a/examples/contracts/custom/Cargo.toml
+++ b/examples/contracts/custom/Cargo.toml
@@ -18,7 +18,6 @@ mt = ["library", "anyhow", "cw-multi-test"]
 
 [dependencies]
 cw1 = { path = "../../interfaces/cw1" }
-cosmwasm-schema = { workspace = true }
 cw-storage-plus = { workspace = true }
 serde = { workspace = true }
 sylvia = { path = "../../../sylvia" }

--- a/examples/contracts/custom/src/bin/schema.rs
+++ b/examples/contracts/custom/src/bin/schema.rs
@@ -1,10 +1,11 @@
-use cosmwasm_schema::write_api;
+use sylvia::cw_schema::write_api;
 
 use custom::contract::sv::{ContractExecMsg, ContractQueryMsg, InstantiateMsg};
 
 #[cfg(not(tarpaulin_include))]
 fn main() {
     write_api! {
+        crate_name: sylvia::cw_schema,
         instantiate: InstantiateMsg,
         execute: ContractExecMsg,
         query: ContractQueryMsg,

--- a/examples/contracts/custom/src/messages.rs
+++ b/examples/contracts/custom/src/messages.rs
@@ -1,17 +1,17 @@
-use cosmwasm_schema::cw_serde;
+use sylvia::cw_schema::cw_serde;
 use sylvia::cw_std::{CustomMsg, CustomQuery};
 
-#[cw_serde]
+#[cw_serde(crate = "sylvia::cw_schema")]
 pub struct CountResponse {
     pub count: u64,
 }
 
-#[cw_serde]
+#[cw_serde(crate = "sylvia::cw_schema")]
 pub enum CounterMsg {
     Increment {},
 }
 
-#[cw_serde]
+#[cw_serde(crate = "sylvia::cw_schema")]
 pub enum CounterQuery {
     Count {},
 }

--- a/examples/contracts/custom/src/multitest/custom_module.rs
+++ b/examples/contracts/custom/src/multitest/custom_module.rs
@@ -1,8 +1,8 @@
-use cosmwasm_schema::schemars::JsonSchema;
 use cw_multi_test::{AppResponse, CosmosRouter, Module};
 use cw_storage_plus::Item;
 use serde::de::DeserializeOwned;
 use std::fmt::Debug;
+use sylvia::cw_schema::schemars::JsonSchema;
 use sylvia::cw_std::{
     to_json_binary, Addr, Api, Binary, BlockInfo, CustomQuery, Empty, Querier, StdError, StdResult,
     Storage,

--- a/examples/contracts/cw1-subkeys/Cargo.toml
+++ b/examples/contracts/cw1-subkeys/Cargo.toml
@@ -12,7 +12,6 @@ mt = ["library", "cw-multi-test", "anyhow"]
 
 [dependencies]
 anyhow = { workspace = true, optional = true }
-cosmwasm-schema = { workspace = true }
 cw-multi-test = { workspace = true, optional = true }
 cw-storage-plus = { workspace = true }
 cw-utils = { workspace = true }

--- a/examples/contracts/cw1-subkeys/src/bin/schema.rs
+++ b/examples/contracts/cw1-subkeys/src/bin/schema.rs
@@ -1,10 +1,11 @@
-use cosmwasm_schema::write_api;
 use cw1_subkeys::contract::sv::{ContractExecMsg, ContractQueryMsg, InstantiateMsg};
+use sylvia::cw_schema::write_api;
 use sylvia::cw_std::Empty;
 
 #[cfg(not(tarpaulin_include))]
 fn main() {
     write_api! {
+        crate_name: sylvia::cw_schema,
         instantiate: InstantiateMsg,
         execute: ContractExecMsg<Empty, Empty>,
         query: ContractQueryMsg<Empty, Empty>,

--- a/examples/contracts/cw1-subkeys/src/responses.rs
+++ b/examples/contracts/cw1-subkeys/src/responses.rs
@@ -1,7 +1,7 @@
 use crate::state::Permissions;
-use cosmwasm_schema::schemars::JsonSchema;
 use cw_utils::{Expiration, NativeBalance};
 use serde::{Deserialize, Serialize};
+use sylvia::cw_schema::schemars::JsonSchema;
 use sylvia::cw_std::Addr;
 use sylvia::schemars;
 
@@ -43,7 +43,7 @@ impl AllowanceInfo {
     /// ```
     /// # use cw_utils::{Expiration, NativeBalance};
     /// # use cw1_subkeys::msg::AllowanceInfo;
-    /// # use cosmwasm_schema::{cw_serde, QueryResponses};
+    /// # use sylvia::cw_schema::{cw_serde, QueryResponses};
     /// # use sylvia::cw_std::coin;
     ///
     /// let mut allows = vec![Allowance {

--- a/examples/contracts/cw1-whitelist/Cargo.toml
+++ b/examples/contracts/cw1-whitelist/Cargo.toml
@@ -16,7 +16,6 @@ library = []
 mt = ["sylvia/mt", "library", "cw-multi-test", "anyhow"]
 
 [dependencies]
-cosmwasm-schema = { workspace = true }
 serde = { workspace = true }
 sylvia = { path = "../../../sylvia" }
 cw1 = { path = "../../interfaces/cw1" }

--- a/examples/contracts/cw1-whitelist/src/bin/schema.rs
+++ b/examples/contracts/cw1-whitelist/src/bin/schema.rs
@@ -1,10 +1,11 @@
-use cosmwasm_schema::write_api;
 use cw1_whitelist::contract::sv::{ContractExecMsg, ContractQueryMsg, InstantiateMsg};
+use sylvia::cw_schema::write_api;
 use sylvia::cw_std::Empty;
 
 #[cfg(not(tarpaulin_include))]
 fn main() {
     write_api! {
+        crate_name: sylvia::cw_schema,
         instantiate: InstantiateMsg,
         execute: ContractExecMsg<Empty, Empty>,
         query: ContractQueryMsg<Empty, Empty>,

--- a/examples/contracts/cw20-base/Cargo.toml
+++ b/examples/contracts/cw20-base/Cargo.toml
@@ -17,7 +17,6 @@ mt = ["library", "cw-multi-test", "anyhow"]
 
 [dependencies]
 anyhow = { workspace = true, optional = true }
-cosmwasm-schema = { workspace = true }
 cw-multi-test = { workspace = true, optional = true }
 cw-storage-plus = { workspace = true }
 cw-utils = { workspace = true }

--- a/examples/contracts/cw20-base/src/bin/schema.rs
+++ b/examples/contracts/cw20-base/src/bin/schema.rs
@@ -1,10 +1,11 @@
-use cosmwasm_schema::write_api;
 use cw20_base::contract::sv::{ContractExecMsg, ContractQueryMsg, InstantiateMsg};
+use sylvia::cw_schema::write_api;
 use sylvia::cw_std::Empty;
 
 #[cfg(not(tarpaulin_include))]
 fn main() {
     write_api! {
+        crate_name: sylvia::cw_schema,
         instantiate: InstantiateMsg,
         execute: ContractExecMsg<Empty, Empty>,
         query: ContractQueryMsg<Empty, Empty>,

--- a/examples/contracts/cw20-base/src/contract.rs
+++ b/examples/contracts/cw20-base/src/contract.rs
@@ -1,13 +1,13 @@
 use crate::error::ContractError;
 use crate::responses::{BalanceResponse, Cw20Coin, Cw20ReceiveMsg, TokenInfoResponse};
 use crate::validation::{validate_accounts, validate_msg, verify_logo};
-use cosmwasm_schema::cw_serde;
 use cw2::{ensure_from_older_version, set_contract_version};
 use cw20_allowances::responses::AllowanceResponse;
 use cw20_marketing::responses::{LogoInfo, MarketingInfoResponse};
 use cw20_marketing::Logo;
 use cw20_minting::responses::MinterResponse;
 use cw_storage_plus::{Item, Map};
+use sylvia::cw_schema::cw_serde;
 use sylvia::cw_std::{
     ensure, Addr, Binary, BlockInfo, DepsMut, Empty, Order, Response, StdError, StdResult, Storage,
     Uint128,
@@ -22,7 +22,7 @@ use sylvia::entry_points;
 const CONTRACT_NAME: &str = "crates.io:cw20-base";
 const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
 
-#[cw_serde]
+#[cw_serde(crate = "sylvia::cw_schema")]
 pub struct TokenInfo {
     pub name: String,
     pub symbol: String,
@@ -37,14 +37,14 @@ impl TokenInfo {
     }
 }
 
-#[cw_serde]
+#[cw_serde(crate = "sylvia::cw_schema")]
 pub struct MinterData {
     pub minter: Addr,
     /// cap is how many more tokens can be issued by the minter
     pub cap: Option<Uint128>,
 }
 
-#[cw_serde]
+#[cw_serde(crate = "sylvia::cw_schema")]
 pub struct InstantiateMarketingInfo {
     pub project: Option<String>,
     pub description: Option<String>,
@@ -52,7 +52,7 @@ pub struct InstantiateMarketingInfo {
     pub logo: Option<Logo>,
 }
 
-#[cw_serde]
+#[cw_serde(crate = "sylvia::cw_schema")]
 pub struct InstantiateMsgData {
     pub name: String,
     pub symbol: String,

--- a/examples/contracts/cw20-base/src/multitest/receiver.rs
+++ b/examples/contracts/cw20-base/src/multitest/receiver.rs
@@ -1,6 +1,6 @@
 use sylvia::cw_std::{Binary, Response, StdError, Uint128};
+use sylvia::interface;
 use sylvia::types::ExecCtx;
-use sylvia::{interface, schemars};
 
 #[interface]
 #[sv::custom(msg=sylvia::cw_std::Empty, query=sylvia::cw_std::Empty)]

--- a/examples/contracts/cw20-base/src/responses.rs
+++ b/examples/contracts/cw20-base/src/responses.rs
@@ -1,9 +1,9 @@
-use cosmwasm_schema::cw_serde;
 use std::fmt;
+use sylvia::cw_schema::cw_serde;
 use sylvia::cw_std::{to_json_binary, Addr, Binary, CosmosMsg, StdResult, Uint128, WasmMsg};
 
 /// Cw20ReceiveMsg should be de/serialized under `Receive()` variant in a ExecuteMsg
-#[cw_serde]
+#[cw_serde(crate = "sylvia::cw_schema")]
 pub struct Cw20ReceiveMsg {
     pub sender: String,
     pub amount: Uint128,
@@ -30,12 +30,12 @@ impl Cw20ReceiveMsg {
 }
 
 // This is just a helper to properly serialize the above message
-#[cw_serde]
+#[cw_serde(crate = "sylvia::cw_schema")]
 enum ReceiverExecuteMsg {
     Receive(Cw20ReceiveMsg),
 }
 
-#[cw_serde]
+#[cw_serde(crate = "sylvia::cw_schema")]
 pub struct Cw20Coin {
     pub address: String,
     pub amount: Uint128,
@@ -53,7 +53,7 @@ impl fmt::Display for Cw20Coin {
     }
 }
 
-#[cw_serde]
+#[cw_serde(crate = "sylvia::cw_schema")]
 pub struct Cw20CoinVerified {
     pub address: Addr,
     pub amount: Uint128,
@@ -71,12 +71,12 @@ impl fmt::Display for Cw20CoinVerified {
     }
 }
 
-#[cw_serde]
+#[cw_serde(crate = "sylvia::cw_schema")]
 pub struct BalanceResponse {
     pub balance: Uint128,
 }
 
-#[cw_serde]
+#[cw_serde(crate = "sylvia::cw_schema")]
 pub struct TokenInfoResponse {
     pub name: String,
     pub symbol: String,

--- a/examples/contracts/entry-points-overriding/Cargo.toml
+++ b/examples/contracts/entry-points-overriding/Cargo.toml
@@ -17,7 +17,6 @@ mt = ["library", "cw-multi-test", "anyhow"]
 
 [dependencies]
 anyhow = { workspace = true, optional = true }
-cosmwasm-schema = { workspace = true }
 cw-multi-test = { workspace = true, optional = true }
 cw-storage-plus = { workspace = true }
 cw-utils = { workspace = true }

--- a/examples/contracts/entry-points-overriding/src/bin/schema.rs
+++ b/examples/contracts/entry-points-overriding/src/bin/schema.rs
@@ -1,4 +1,4 @@
-use cosmwasm_schema::write_api;
+use sylvia::cw_schema::write_api;
 
 use entry_points_overriding::contract::sv::{ContractQueryMsg, InstantiateMsg};
 use entry_points_overriding::messages::{CustomExecMsg, SudoMsg};
@@ -6,6 +6,7 @@ use entry_points_overriding::messages::{CustomExecMsg, SudoMsg};
 #[cfg(not(tarpaulin_include))]
 fn main() {
     write_api! {
+        crate_name: sylvia::cw_schema,
         instantiate: InstantiateMsg,
         execute: CustomExecMsg,
         query: ContractQueryMsg,

--- a/examples/contracts/entry-points-overriding/src/messages.rs
+++ b/examples/contracts/entry-points-overriding/src/messages.rs
@@ -1,21 +1,21 @@
-use cosmwasm_schema::cw_serde;
+use sylvia::cw_schema::cw_serde;
 use sylvia::cw_std::{DepsMut, Env, MessageInfo, Response, StdError, StdResult};
 use sylvia::types::ExecCtx;
 
 use crate::contract::sv::ContractExecMsg;
 use crate::contract::CounterContract;
 
-#[cw_serde]
+#[cw_serde(crate = "sylvia::cw_schema")]
 pub struct CountResponse {
     pub count: u32,
 }
 
-#[cw_serde]
+#[cw_serde(crate = "sylvia::cw_schema")]
 pub enum SudoMsg {
     SetCountToThree {},
 }
 
-#[cw_serde]
+#[cw_serde(crate = "sylvia::cw_schema")]
 pub enum UserExecMsg {
     IncreaseByOne {},
 }
@@ -29,7 +29,7 @@ pub fn increase_by_one(ctx: ExecCtx) -> StdResult<Response> {
     Ok(Response::new())
 }
 
-#[cw_serde]
+#[cw_serde(crate = "sylvia::cw_schema")]
 pub enum CustomExecMsg {
     ContractExec(ContractExecMsg),
     CustomExec(UserExecMsg),

--- a/examples/contracts/generic_contract/Cargo.toml
+++ b/examples/contracts/generic_contract/Cargo.toml
@@ -17,7 +17,6 @@ mt = ["library", "cw-multi-test", "anyhow"]
 
 [dependencies]
 anyhow = { workspace = true, optional = true }
-cosmwasm-schema = { workspace = true }
 cw-multi-test = { workspace = true, optional = true }
 cw-storage-plus = { workspace = true }
 cw-utils = { workspace = true }

--- a/examples/contracts/generic_contract/src/bin/schema.rs
+++ b/examples/contracts/generic_contract/src/bin/schema.rs
@@ -1,4 +1,4 @@
-use cosmwasm_schema::write_api;
+use sylvia::cw_schema::write_api;
 
 #[cfg(not(tarpaulin_include))]
 fn main() {
@@ -6,6 +6,7 @@ fn main() {
     use generic_contract::contract::SvCustomMsg;
 
     write_api! {
+        crate_name: sylvia::cw_schema,
         instantiate: InstantiateMsg<SvCustomMsg>,
         execute: ContractExecMsg<SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg,>,
         query: ContractQueryMsg<SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg, SvCustomMsg,>,

--- a/examples/contracts/generic_contract/src/contract.rs
+++ b/examples/contracts/generic_contract/src/contract.rs
@@ -7,11 +7,11 @@ use sylvia::{contract, schemars};
 #[cfg(not(feature = "library"))]
 use sylvia::entry_points;
 
-#[cosmwasm_schema::cw_serde]
+#[sylvia::cw_schema::cw_serde(crate = "sylvia::cw_schema")]
 pub struct SvCustomMsg;
 impl sylvia::cw_std::CustomMsg for SvCustomMsg {}
 
-#[cosmwasm_schema::cw_serde]
+#[sylvia::cw_schema::cw_serde(crate = "sylvia::cw_schema")]
 pub struct SvCustomQuery;
 impl sylvia::cw_std::CustomQuery for SvCustomQuery {}
 

--- a/examples/contracts/generic_iface_on_contract/Cargo.toml
+++ b/examples/contracts/generic_iface_on_contract/Cargo.toml
@@ -17,7 +17,6 @@ mt = ["library", "cw-multi-test", "anyhow"]
 
 [dependencies]
 anyhow = { workspace = true, optional = true }
-cosmwasm-schema = { workspace = true }
 cw-multi-test = { workspace = true, optional = true }
 cw-storage-plus = { workspace = true }
 cw-utils = { workspace = true }

--- a/examples/contracts/generic_iface_on_contract/src/bin/schema.rs
+++ b/examples/contracts/generic_iface_on_contract/src/bin/schema.rs
@@ -1,4 +1,4 @@
-use cosmwasm_schema::write_api;
+use sylvia::cw_schema::write_api;
 
 #[cfg(not(tarpaulin_include))]
 fn main() {
@@ -7,6 +7,7 @@ fn main() {
     };
 
     write_api! {
+        crate_name: sylvia::cw_schema,
         instantiate: InstantiateMsg,
         execute: ContractExecMsg,
         query: ContractQueryMsg,

--- a/examples/contracts/generic_iface_on_contract/src/contract.rs
+++ b/examples/contracts/generic_iface_on_contract/src/contract.rs
@@ -7,11 +7,11 @@ use sylvia::entry_points;
 
 pub struct NonGenericContract;
 
-#[cosmwasm_schema::cw_serde]
+#[sylvia::cw_schema::cw_serde(crate = "sylvia::cw_schema")]
 pub struct SvCustomMsg;
 impl sylvia::cw_std::CustomMsg for SvCustomMsg {}
 
-#[cosmwasm_schema::cw_serde]
+#[sylvia::cw_schema::cw_serde(crate = "sylvia::cw_schema")]
 pub struct SvCustomQuery;
 impl sylvia::cw_std::CustomQuery for SvCustomQuery {}
 

--- a/examples/contracts/generics_forwarded/Cargo.toml
+++ b/examples/contracts/generics_forwarded/Cargo.toml
@@ -17,7 +17,6 @@ mt = ["library", "cw-multi-test", "anyhow"]
 
 [dependencies]
 anyhow = { workspace = true, optional = true }
-cosmwasm-schema = { workspace = true }
 cw-multi-test = { workspace = true, optional = true }
 cw-storage-plus = { workspace = true }
 cw-utils = { workspace = true }

--- a/examples/contracts/generics_forwarded/src/bin/schema.rs
+++ b/examples/contracts/generics_forwarded/src/bin/schema.rs
@@ -1,4 +1,4 @@
-use cosmwasm_schema::write_api;
+use sylvia::cw_schema::write_api;
 
 #[cfg(not(tarpaulin_include))]
 fn main() {
@@ -6,6 +6,7 @@ fn main() {
     use generics_forwarded::contract::{SvCustomMsg, SvCustomQuery};
 
     write_api! {
+        crate_name: sylvia::cw_schema,
         instantiate: InstantiateMsg<SvCustomMsg>,
         // We should rethink this. We generate messages generic over types used in the methods.
         // To do so we however have to merge generics from the contract and interfaces methods.

--- a/examples/contracts/generics_forwarded/src/contract.rs
+++ b/examples/contracts/generics_forwarded/src/contract.rs
@@ -7,11 +7,11 @@ use sylvia::types::{
 };
 use sylvia::{contract, schemars};
 
-#[cosmwasm_schema::cw_serde]
+#[sylvia::cw_schema::cw_serde(crate = "sylvia::cw_schema")]
 pub struct SvCustomMsg;
 impl sylvia::cw_std::CustomMsg for SvCustomMsg {}
 
-#[cosmwasm_schema::cw_serde]
+#[sylvia::cw_schema::cw_serde(crate = "sylvia::cw_schema")]
 pub struct SvCustomQuery;
 impl sylvia::cw_std::CustomQuery for SvCustomQuery {}
 

--- a/examples/contracts/generics_forwarded/src/cw1.rs
+++ b/examples/contracts/generics_forwarded/src/cw1.rs
@@ -1,7 +1,7 @@
-use cosmwasm_schema::schemars::JsonSchema;
 use cw1::{CanExecuteResp, Cw1};
 use serde::de::DeserializeOwned;
 use serde::Deserialize;
+use sylvia::cw_schema::schemars::JsonSchema;
 use sylvia::cw_std::{CosmosMsg, CustomMsg, Empty, Response, StdResult};
 use sylvia::types::{CustomQuery, ExecCtx, QueryCtx};
 

--- a/examples/interfaces/custom-and-generic/Cargo.toml
+++ b/examples/interfaces/custom-and-generic/Cargo.toml
@@ -12,7 +12,6 @@ homepage = "https://cosmwasm.com"
 mt = ["sylvia/mt"]
 
 [dependencies]
-cosmwasm-schema = { workspace = true }
 serde = { workspace = true }
 sylvia = { path = "../../../sylvia" }
 

--- a/examples/interfaces/custom-and-generic/src/lib.rs
+++ b/examples/interfaces/custom-and-generic/src/lib.rs
@@ -1,7 +1,7 @@
 use sylvia::cw_std::{CosmosMsg, Response, StdError};
 
+use sylvia::interface;
 use sylvia::types::{CustomMsg, CustomQuery, ExecCtx, QueryCtx, SudoCtx};
-use sylvia::{interface, schemars};
 
 #[interface]
 pub trait CustomAndGeneric {
@@ -77,10 +77,10 @@ mod tests {
 
     use crate::sv::Querier;
 
-    #[cosmwasm_schema::cw_serde]
+    #[sylvia::cw_schema::cw_serde(crate = "sylvia::cw_schema")]
     pub struct SvCustomMsg;
     impl sylvia::cw_std::CustomMsg for SvCustomMsg {}
-    #[cosmwasm_schema::cw_serde]
+    #[sylvia::cw_schema::cw_serde(crate = "sylvia::cw_schema")]
     pub struct SvCustomQuery;
     impl sylvia::cw_std::CustomQuery for SvCustomQuery {}
 

--- a/examples/interfaces/cw1/Cargo.toml
+++ b/examples/interfaces/cw1/Cargo.toml
@@ -12,7 +12,6 @@ homepage = "https://cosmwasm.com"
 mt = ["sylvia/mt"]
 
 [dependencies]
-cosmwasm-schema = { workspace = true }
 serde = { workspace = true }
 sylvia = { path = "../../../sylvia" }
 

--- a/examples/interfaces/cw20-allowances/Cargo.toml
+++ b/examples/interfaces/cw20-allowances/Cargo.toml
@@ -12,7 +12,6 @@ homepage = "https://cosmwasm.com"
 mt = ["sylvia/mt"]
 
 [dependencies]
-cosmwasm-schema = { workspace = true }
 serde = { workspace = true }
 sylvia = { path = "../../../sylvia" }
 cw-utils = { workspace = true }

--- a/examples/interfaces/cw20-allowances/src/lib.rs
+++ b/examples/interfaces/cw20-allowances/src/lib.rs
@@ -5,8 +5,8 @@ use responses::{
     AllAccountsResponse, AllAllowancesResponse, AllSpenderAllowancesResponse, AllowanceResponse,
 };
 use sylvia::cw_std::{Binary, Response, StdError, StdResult, Uint128};
+use sylvia::interface;
 use sylvia::types::{CustomMsg, CustomQuery, ExecCtx, QueryCtx};
-use sylvia::{interface, schemars};
 
 #[interface]
 pub trait Cw20Allowances {

--- a/examples/interfaces/cw20-allowances/src/responses.rs
+++ b/examples/interfaces/cw20-allowances/src/responses.rs
@@ -1,40 +1,44 @@
-use cosmwasm_schema::cw_serde;
 use cw_utils::Expiration;
 use serde::{Deserialize, Serialize};
+use sylvia::cw_schema::cw_serde;
 use sylvia::cw_std::Uint128;
-use sylvia::schemars;
+use sylvia::schemars::JsonSchema;
 
-#[derive(Serialize, Deserialize, Clone, PartialEq, schemars::JsonSchema, Debug, Default)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug, Default)]
+#[schemars(crate = "sylvia::cw_schema::schemars")]
 pub struct AllowanceResponse {
     pub allowance: Uint128,
     pub expires: Expiration,
 }
 
-#[cw_serde]
+#[cw_serde(crate = "sylvia::cw_schema")]
 pub struct AllowanceInfo {
     pub spender: String,
     pub allowance: Uint128,
     pub expires: Expiration,
 }
 
-#[derive(Serialize, Deserialize, Clone, PartialEq, schemars::JsonSchema, Debug, Default)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug, Default)]
+#[schemars(crate = "sylvia::cw_schema::schemars")]
 pub struct AllAllowancesResponse {
     pub allowances: Vec<AllowanceInfo>,
 }
 
-#[cw_serde]
+#[cw_serde(crate = "sylvia::cw_schema")]
 pub struct SpenderAllowanceInfo {
     pub owner: String,
     pub allowance: Uint128,
     pub expires: Expiration,
 }
 
-#[derive(Serialize, Deserialize, Clone, PartialEq, schemars::JsonSchema, Debug, Default)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug, Default)]
+#[schemars(crate = "sylvia::cw_schema::schemars")]
 pub struct AllSpenderAllowancesResponse {
     pub allowances: Vec<SpenderAllowanceInfo>,
 }
 
-#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, schemars::JsonSchema, Debug, Default)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, JsonSchema, Debug, Default)]
+#[schemars(crate = "sylvia::cw_schema::schemars")]
 pub struct AllAccountsResponse {
     pub accounts: Vec<String>,
 }

--- a/examples/interfaces/cw20-marketing/Cargo.toml
+++ b/examples/interfaces/cw20-marketing/Cargo.toml
@@ -12,7 +12,6 @@ homepage = "https://cosmwasm.com"
 mt = ["sylvia/mt"]
 
 [dependencies]
-cosmwasm-schema = { workspace = true }
 serde = { workspace = true }
 sylvia = { path = "../../../sylvia" }
 

--- a/examples/interfaces/cw20-marketing/src/lib.rs
+++ b/examples/interfaces/cw20-marketing/src/lib.rs
@@ -1,13 +1,13 @@
 pub mod responses;
 
-use cosmwasm_schema::cw_serde;
 use responses::{DownloadLogoResponse, MarketingInfoResponse};
+use sylvia::cw_schema::cw_serde;
 use sylvia::cw_std::{Binary, Response, StdError, StdResult};
+use sylvia::interface;
 use sylvia::types::{CustomMsg, CustomQuery, ExecCtx, QueryCtx};
-use sylvia::{interface, schemars};
 
 /// This is used for uploading logo data, or setting it in InstantiateData
-#[cw_serde]
+#[cw_serde(crate = "sylvia::cw_schema")]
 pub enum Logo {
     /// A reference to an externally hosted logo. Must be a valid HTTP or HTTPS URL.
     Url(String),
@@ -17,7 +17,7 @@ pub enum Logo {
 
 /// This is used to store the logo on the blockchain in an accepted format.
 /// Enforce maximum size of 5KB on all variants.
-#[cw_serde]
+#[cw_serde(crate = "sylvia::cw_schema")]
 pub enum EmbeddedLogo {
     /// Store the Logo as an SVG file. The content must conform to the spec
     /// at https://en.wikipedia.org/wiki/Scalable_Vector_Graphics

--- a/examples/interfaces/cw20-marketing/src/responses.rs
+++ b/examples/interfaces/cw20-marketing/src/responses.rs
@@ -1,11 +1,11 @@
-use cosmwasm_schema::cw_serde;
 use serde::{Deserialize, Serialize};
+use sylvia::cw_schema::cw_serde;
 use sylvia::cw_std::{Addr, Binary};
 use sylvia::schemars;
 
 /// This is used to display logo info, provide a link or inform there is one
 /// that can be downloaded from the blockchain itself
-#[cw_serde]
+#[cw_serde(crate = "sylvia::cw_schema")]
 pub enum LogoInfo {
     /// A reference to an externally hosted logo. Must be a valid HTTP or HTTPS URL.
     Url(String),
@@ -27,7 +27,7 @@ pub struct MarketingInfoResponse {
 
 /// When we download an embedded logo, we get this response type.
 /// We expect a SPA to be able to accept this info and display it.
-#[cw_serde]
+#[cw_serde(crate = "sylvia::cw_schema")]
 pub struct DownloadLogoResponse {
     pub mime_type: String,
     pub data: Binary,

--- a/examples/interfaces/cw20-minting/Cargo.toml
+++ b/examples/interfaces/cw20-minting/Cargo.toml
@@ -12,7 +12,6 @@ homepage = "https://cosmwasm.com"
 mt = ["sylvia/mt"]
 
 [dependencies]
-cosmwasm-schema = { workspace = true }
 serde = { workspace = true }
 sylvia = { path = "../../../sylvia" }
 

--- a/examples/interfaces/cw20-minting/src/lib.rs
+++ b/examples/interfaces/cw20-minting/src/lib.rs
@@ -2,8 +2,8 @@ pub mod responses;
 
 use responses::MinterResponse;
 use sylvia::cw_std::{Response, StdError, StdResult, Uint128};
+use sylvia::interface;
 use sylvia::types::{CustomMsg, CustomQuery, ExecCtx, QueryCtx};
-use sylvia::{interface, schemars};
 
 #[interface]
 pub trait Cw20Minting {

--- a/examples/interfaces/cw20-minting/src/responses.rs
+++ b/examples/interfaces/cw20-minting/src/responses.rs
@@ -1,7 +1,7 @@
-use cosmwasm_schema::cw_serde;
+use sylvia::cw_schema::cw_serde;
 use sylvia::cw_std::Uint128;
 
-#[cw_serde]
+#[cw_serde(crate = "sylvia::cw_schema")]
 pub struct MinterResponse {
     pub minter: String,
     /// cap is a hard cap on total supply that can be achieved by minting.

--- a/examples/interfaces/cw4/Cargo.toml
+++ b/examples/interfaces/cw4/Cargo.toml
@@ -12,7 +12,6 @@ homepage = "https://cosmwasm.com"
 mt = ["sylvia/mt"]
 
 [dependencies]
-cosmwasm-schema = { workspace = true }
 serde = { workspace = true }
 sylvia = { path = "../../../sylvia" }
 

--- a/examples/interfaces/cw4/src/lib.rs
+++ b/examples/interfaces/cw4/src/lib.rs
@@ -4,8 +4,8 @@ use responses::{
     AdminResponse, HooksResponse, MemberListResponse, MemberResponse, TotalWeightResponse,
 };
 use sylvia::cw_std::{Response, StdError};
+use sylvia::interface;
 use sylvia::types::{CustomMsg, CustomQuery, ExecCtx, QueryCtx};
-use sylvia::{interface, schemars};
 
 #[interface]
 pub trait Cw4 {

--- a/examples/interfaces/cw4/src/responses.rs
+++ b/examples/interfaces/cw4/src/responses.rs
@@ -1,6 +1,6 @@
-use cosmwasm_schema::cw_serde;
+use sylvia::cw_schema::cw_serde;
 
-#[cw_serde]
+#[cw_serde(crate = "sylvia::cw_schema")]
 pub struct AdminResponse {
     pub admin: Option<String>,
 }
@@ -8,28 +8,28 @@ pub struct AdminResponse {
 /// A group member has a weight associated with them.
 /// This may all be equal, or may have meaning in the app that
 /// makes use of the group (eg. voting power)
-#[cw_serde]
+#[cw_serde(crate = "sylvia::cw_schema")]
 pub struct Member {
     pub addr: String,
     pub weight: u64,
 }
 
-#[cw_serde]
+#[cw_serde(crate = "sylvia::cw_schema")]
 pub struct MemberListResponse {
     pub members: Vec<Member>,
 }
 
-#[cw_serde]
+#[cw_serde(crate = "sylvia::cw_schema")]
 pub struct MemberResponse {
     pub weight: Option<u64>,
 }
 
-#[cw_serde]
+#[cw_serde(crate = "sylvia::cw_schema")]
 pub struct TotalWeightResponse {
     pub weight: u64,
 }
 
-#[cw_serde]
+#[cw_serde(crate = "sylvia::cw_schema")]
 pub struct HooksResponse {
     pub hooks: Vec<String>,
 }

--- a/examples/interfaces/generic/Cargo.toml
+++ b/examples/interfaces/generic/Cargo.toml
@@ -12,7 +12,6 @@ homepage = "https://cosmwasm.com"
 mt = ["sylvia/mt"]
 
 [dependencies]
-cosmwasm-schema = { workspace = true }
 serde = { workspace = true }
 sylvia = { path = "../../../sylvia" }
 

--- a/examples/interfaces/generic/src/lib.rs
+++ b/examples/interfaces/generic/src/lib.rs
@@ -1,7 +1,7 @@
 use sylvia::cw_std::{CosmosMsg, Response, StdError};
 
+use sylvia::interface;
 use sylvia::types::{CustomMsg, ExecCtx, QueryCtx, SudoCtx};
-use sylvia::{interface, schemars};
 
 #[interface]
 #[sv::custom(msg=sylvia::cw_std::Empty, query=sylvia::cw_std::Empty)]
@@ -76,7 +76,7 @@ mod tests {
 
     use crate::sv::Querier;
 
-    #[cosmwasm_schema::cw_serde]
+    #[sylvia::cw_schema::cw_serde(crate = "sylvia::cw_schema")]
     pub struct SvCustomMsg;
     impl sylvia::cw_std::CustomMsg for SvCustomMsg {}
 

--- a/examples/interfaces/whitelist/Cargo.toml
+++ b/examples/interfaces/whitelist/Cargo.toml
@@ -12,7 +12,6 @@ homepage = "https://cosmwasm.com"
 mt = ["sylvia/mt"]
 
 [dependencies]
-cosmwasm-schema = { workspace = true }
 serde = { workspace = true }
 sylvia = { path = "../../../sylvia" }
 

--- a/examples/interfaces/whitelist/src/lib.rs
+++ b/examples/interfaces/whitelist/src/lib.rs
@@ -1,7 +1,7 @@
 use responses::AdminListResponse;
 use sylvia::cw_std::{Response, StdError, StdResult};
+use sylvia::interface;
 use sylvia::types::{CustomMsg, CustomQuery, ExecCtx, QueryCtx};
-use sylvia::{interface, schemars};
 
 pub mod responses;
 

--- a/sylvia-derive/src/contract/communication/enum_msg.rs
+++ b/sylvia-derive/src/contract/communication/enum_msg.rs
@@ -76,12 +76,7 @@ impl<'a> EnumMessage<'a> {
 
         let ctx_type = msg_ty.emit_ctx_type(&custom.query_or_default());
         let ret_type = msg_ty.emit_result_type(&custom.msg_or_default(), &error.error);
-
-        let derive_query = match msg_ty {
-            MsgType::Query => quote! { #sylvia ::cw_schema::QueryResponses },
-            _ => quote! {},
-        };
-
+        let derive_call = msg_ty.emit_derive_call();
         let ep_name = msg_ty.emit_ep_name();
         let messages_fn_name = Ident::new(&format!("{}_messages", ep_name), contract.span());
 
@@ -96,7 +91,7 @@ impl<'a> EnumMessage<'a> {
 
         quote! {
             #[allow(clippy::derive_partial_eq_without_eq)]
-            #[derive(#sylvia ::serde::Serialize, #sylvia ::serde::Deserialize, Clone, Debug, PartialEq, #sylvia ::schemars::JsonSchema, #derive_query )]
+            #derive_call
             #( #[ #msg_attrs_to_forward ] )*
             #[serde(rename_all="snake_case")]
             pub enum #enum_name #bracketed_used_generics {

--- a/sylvia-derive/src/types/msg_type.rs
+++ b/sylvia-derive/src/types/msg_type.rs
@@ -155,12 +155,18 @@ impl MsgType {
 
     pub fn emit_derive_call(&self) -> TokenStream {
         let sylvia = crate_module();
+        let cw_schema = quote! { #sylvia:: cw_schema }.to_string();
+        let schemars = quote! { #sylvia:: cw_schema::schemars }.to_string();
+
         match self {
             MsgType::Query => quote! {
                 #[derive(#sylvia ::serde::Serialize, #sylvia ::serde::Deserialize, Clone, Debug, PartialEq, #sylvia ::schemars::JsonSchema, #sylvia:: cw_schema::QueryResponses)]
+                #[schemars(crate = #schemars )]
+                #[query_responses(crate = #cw_schema )]
             },
             _ => quote! {
                 #[derive(#sylvia ::serde::Serialize, #sylvia ::serde::Deserialize, Clone, Debug, PartialEq, #sylvia ::schemars::JsonSchema)]
+                #[schemars(crate = #schemars )]
             },
         }
     }


### PR DESCRIPTION
This makes `cosmwasm_schema` dependency optional on user side, however due to how `cosmwasm_schema` and `schemars` is constructed it requires user to specify path to add some more info to macros like so:

```rust
#[cw_serde(crate = "sylvia::cw_schema")]
pub struct MyType {}
```

```rust
write_api! {
    crate_name: sylvia::cw_schema,

    instantiate: InstantiateMsg,
    execute: ContractExecMsg<Empty, Empty>,
    query: ContractQueryMsg<Empty, Empty>,
}
```

Users however can still add `cosmwasm_schema` to their deps and this change allows them to skip this dependency if they want to.