### PR TITLE
feat: Make serde dep user side obsolete

### DIFF
--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -409,7 +409,6 @@ dependencies = [
  "cw-multi-test",
  "cw-storage-plus",
  "cw1",
- "serde",
  "sylvia",
 ]
 
@@ -418,8 +417,6 @@ name = "custom-and-generic"
 version = "0.5.0"
 dependencies = [
  "anyhow",
- "cw-multi-test",
- "serde",
  "sylvia",
 ]
 
@@ -472,8 +469,6 @@ name = "cw1"
 version = "0.5.0"
 dependencies = [
  "anyhow",
- "cw-multi-test",
- "serde",
  "sylvia",
 ]
 
@@ -482,13 +477,11 @@ name = "cw1-subkeys"
 version = "0.5.0"
 dependencies = [
  "anyhow",
- "cw-multi-test",
  "cw-storage-plus",
  "cw-utils",
  "cw1",
  "cw1-whitelist",
  "cw2",
- "serde",
  "sylvia",
  "thiserror",
  "whitelist",
@@ -500,11 +493,9 @@ version = "0.5.0"
 dependencies = [
  "anyhow",
  "assert_matches",
- "cw-multi-test",
  "cw-storage-plus",
  "cw1",
  "cw2",
- "serde",
  "sylvia",
  "thiserror",
  "whitelist",
@@ -530,9 +521,7 @@ name = "cw20-allowances"
 version = "0.5.0"
 dependencies = [
  "anyhow",
- "cw-multi-test",
  "cw-utils",
- "serde",
  "sylvia",
 ]
 
@@ -542,7 +531,6 @@ version = "0.5.0"
 dependencies = [
  "anyhow",
  "assert_matches",
- "cw-multi-test",
  "cw-storage-plus",
  "cw-utils",
  "cw2",
@@ -550,7 +538,6 @@ dependencies = [
  "cw20-marketing",
  "cw20-minting",
  "semver",
- "serde",
  "sylvia",
  "thiserror",
 ]
@@ -560,8 +547,6 @@ name = "cw20-marketing"
 version = "0.5.0"
 dependencies = [
  "anyhow",
- "cw-multi-test",
- "serde",
  "sylvia",
 ]
 
@@ -570,8 +555,6 @@ name = "cw20-minting"
 version = "0.5.0"
 dependencies = [
  "anyhow",
- "cw-multi-test",
- "serde",
  "sylvia",
 ]
 
@@ -580,8 +563,6 @@ name = "cw4"
 version = "0.5.0"
 dependencies = [
  "anyhow",
- "cw-multi-test",
- "serde",
  "sylvia",
 ]
 
@@ -714,7 +695,6 @@ dependencies = [
  "cw-multi-test",
  "cw-storage-plus",
  "cw-utils",
- "serde",
  "sylvia",
 ]
 
@@ -745,8 +725,6 @@ name = "generic"
 version = "0.5.0"
 dependencies = [
  "anyhow",
- "cw-multi-test",
- "serde",
  "sylvia",
 ]
 
@@ -767,12 +745,10 @@ version = "0.5.0"
 dependencies = [
  "anyhow",
  "custom-and-generic",
- "cw-multi-test",
  "cw-storage-plus",
  "cw-utils",
  "cw1",
  "generic",
- "serde",
  "sylvia",
 ]
 
@@ -782,12 +758,10 @@ version = "0.5.0"
 dependencies = [
  "anyhow",
  "custom-and-generic",
- "cw-multi-test",
  "cw-storage-plus",
  "cw-utils",
  "cw1",
  "generic",
- "serde",
  "sylvia",
 ]
 
@@ -797,12 +771,10 @@ version = "0.5.0"
 dependencies = [
  "anyhow",
  "custom-and-generic",
- "cw-multi-test",
  "cw-storage-plus",
  "cw-utils",
  "cw1",
  "generic",
- "serde",
  "sylvia",
  "thiserror",
 ]
@@ -1447,8 +1419,6 @@ name = "whitelist"
 version = "0.5.0"
 dependencies = [
  "anyhow",
- "cw-multi-test",
- "serde",
  "sylvia",
 ]
 

--- a/examples/contracts/custom/Cargo.toml
+++ b/examples/contracts/custom/Cargo.toml
@@ -19,12 +19,10 @@ mt = ["library", "anyhow", "cw-multi-test"]
 [dependencies]
 cw1 = { path = "../../interfaces/cw1" }
 cw-storage-plus = { workspace = true }
-serde = { workspace = true }
 sylvia = { path = "../../../sylvia" }
 cw-multi-test = { workspace = true, optional = true }
 anyhow = { workspace = true, optional = true }
 
 [dev-dependencies]
 anyhow = { workspace = true }
-cw-multi-test = { workspace = true }
 sylvia = { path = "../../../sylvia", features = ["mt"] }

--- a/examples/contracts/custom/src/bin/schema.rs
+++ b/examples/contracts/custom/src/bin/schema.rs
@@ -2,7 +2,6 @@ use sylvia::cw_schema::write_api;
 
 use custom::contract::sv::{ContractExecMsg, ContractQueryMsg, InstantiateMsg};
 
-#[cfg(not(tarpaulin_include))]
 fn main() {
     write_api! {
         crate_name: sylvia::cw_schema,

--- a/examples/contracts/custom/src/contract.rs
+++ b/examples/contracts/custom/src/contract.rs
@@ -1,7 +1,7 @@
 use cw_storage_plus::Item;
+use sylvia::contract;
 use sylvia::cw_std::{CosmosMsg, QueryRequest, Response, StdResult};
 use sylvia::types::{ExecCtx, InstantiateCtx, QueryCtx, SudoCtx};
-use sylvia::{contract, schemars};
 
 #[cfg(not(feature = "library"))]
 use sylvia::entry_points;

--- a/examples/contracts/custom/src/multitest/custom_module.rs
+++ b/examples/contracts/custom/src/multitest/custom_module.rs
@@ -1,12 +1,12 @@
-use cw_multi_test::{AppResponse, CosmosRouter, Module};
 use cw_storage_plus::Item;
-use serde::de::DeserializeOwned;
 use std::fmt::Debug;
+use sylvia::cw_multi_test::{AppResponse, CosmosRouter, Module};
 use sylvia::cw_schema::schemars::JsonSchema;
 use sylvia::cw_std::{
     to_json_binary, Addr, Api, Binary, BlockInfo, CustomQuery, Empty, Querier, StdError, StdResult,
     Storage,
 };
+use sylvia::serde::de::DeserializeOwned;
 
 use crate::messages::{CountResponse, CounterMsg, CounterQuery};
 

--- a/examples/contracts/custom/src/multitest/tests.rs
+++ b/examples/contracts/custom/src/multitest/tests.rs
@@ -1,10 +1,8 @@
-use cw_multi_test::IntoBech32;
+use sylvia::cw_multi_test::{BasicAppBuilder, IntoBech32};
 use sylvia::multitest::App;
 
-use crate::contract::sv::mt::CodeId;
-
 use super::custom_module::CustomModule;
-
+use crate::contract::sv::mt::CodeId;
 use crate::contract::sv::mt::CustomContractProxy;
 
 use cw1::sv::mt::Cw1Proxy;
@@ -14,7 +12,7 @@ use sylvia::cw_std::CosmosMsg;
 fn test_custom() {
     let owner = "owner".into_bech32();
 
-    let mt_app = cw_multi_test::BasicAppBuilder::new_custom()
+    let mt_app = BasicAppBuilder::new_custom()
         .with_custom(CustomModule::default())
         .build(|router, _, storage| {
             router.custom.save_counter(storage, 0).unwrap();

--- a/examples/contracts/cw1-subkeys/Cargo.toml
+++ b/examples/contracts/cw1-subkeys/Cargo.toml
@@ -8,24 +8,21 @@ crate-type = ["cdylib", "rlib"]
 
 [features]
 library = []
-mt = ["library", "cw-multi-test", "anyhow"]
+mt = ["library", "anyhow", "sylvia/mt"]
 
 [dependencies]
 anyhow = { workspace = true, optional = true }
-cw-multi-test = { workspace = true, optional = true }
 cw-storage-plus = { workspace = true }
 cw-utils = { workspace = true }
 cw1 = { path = "../../interfaces/cw1" }
 whitelist = { path = "../../interfaces/whitelist" }
 cw1-whitelist = { path = "../cw1-whitelist", features = ["library"] }
 cw2 = { workspace = true }
-serde = { workspace = true }
 sylvia = { path = "../../../sylvia" }
 thiserror = { workspace = true }
 
 [dev-dependencies]
 anyhow = { workspace = true }
-cw-multi-test = { workspace = true }
 sylvia = { path = "../../../sylvia", features = ["mt"] }
-cw1-whitelist = { path = "../cw1-whitelist", features = ["library", "mt"] }
+cw1-whitelist = { path = "../cw1-whitelist", features = ["mt"] }
 cw1 = { path = "../../interfaces/cw1", features = ["mt"] }

--- a/examples/contracts/cw1-subkeys/src/bin/schema.rs
+++ b/examples/contracts/cw1-subkeys/src/bin/schema.rs
@@ -2,7 +2,6 @@ use cw1_subkeys::contract::sv::{ContractExecMsg, ContractQueryMsg, InstantiateMs
 use sylvia::cw_schema::write_api;
 use sylvia::cw_std::Empty;
 
-#[cfg(not(tarpaulin_include))]
 fn main() {
     write_api! {
         crate_name: sylvia::cw_schema,

--- a/examples/contracts/cw1-subkeys/src/contract.rs
+++ b/examples/contracts/cw1-subkeys/src/contract.rs
@@ -2,13 +2,15 @@ use cw1_whitelist::contract::Cw1WhitelistContract;
 use cw2::set_contract_version;
 use cw_storage_plus::{Bound, Map};
 use cw_utils::Expiration;
+use sylvia::contract;
 use sylvia::cw_std::{
-    ensure, ensure_ne, Addr, BankMsg, Coin, CosmosMsg, Deps, DistributionMsg, Empty, Env, Order,
-    Response, StakingMsg, StdResult,
+    ensure, ensure_ne, Addr, BankMsg, Coin, CosmosMsg, Deps, DistributionMsg, Env, Order, Response,
+    StakingMsg, StdResult,
 };
 use sylvia::types::{CustomMsg, CustomQuery, ExecCtx, InstantiateCtx, QueryCtx};
-use sylvia::{contract, schemars};
 
+#[cfg(not(feature = "library"))]
+use sylvia::cw_std::Empty;
 #[cfg(not(feature = "library"))]
 use sylvia::entry_points;
 

--- a/examples/contracts/cw1-subkeys/src/lib.rs
+++ b/examples/contracts/cw1-subkeys/src/lib.rs
@@ -1,7 +1,7 @@
 pub mod contract;
 mod cw1;
 pub mod error;
-#[cfg(any(test, feature = "tests"))]
+#[cfg(test)]
 pub mod multitest;
 pub mod responses;
 pub mod state;

--- a/examples/contracts/cw1-subkeys/src/multitest/tests.rs
+++ b/examples/contracts/cw1-subkeys/src/multitest/tests.rs
@@ -1,6 +1,6 @@
 use cw2::{query_contract_info, ContractVersion};
-use cw_multi_test::IntoBech32;
 use cw_utils::{Expiration, NativeBalance};
+use sylvia::cw_multi_test::IntoBech32;
 use sylvia::cw_std::{coin, coins, Addr};
 use sylvia::multitest::App;
 
@@ -59,7 +59,7 @@ fn get_contract_version_works() {
 }
 
 mod allowance {
-    use cw_multi_test::next_block;
+    use sylvia::cw_multi_test::next_block;
 
     use crate::responses::AllowanceInfo;
     use crate::state::Allowance;
@@ -425,7 +425,7 @@ mod cw1_execute {
         let admin = "admin".into_bech32();
         let non_admin = Addr::unchecked("non_admin");
 
-        let app = cw_multi_test::App::new(|router, _api, storage| {
+        let app = sylvia::cw_multi_test::App::new(|router, _api, storage| {
             router
                 .bank
                 .init_balance(storage, &admin, coins(2345, ATOM))

--- a/examples/contracts/cw1-subkeys/src/responses.rs
+++ b/examples/contracts/cw1-subkeys/src/responses.rs
@@ -1,11 +1,12 @@
 use crate::state::Permissions;
 use cw_utils::{Expiration, NativeBalance};
-use serde::{Deserialize, Serialize};
 use sylvia::cw_schema::schemars::JsonSchema;
 use sylvia::cw_std::Addr;
 use sylvia::schemars;
+use sylvia::serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug, Default)]
+#[serde(crate = "sylvia::serde")]
 pub struct AllAllowancesResponse {
     pub allowances: Vec<AllowanceInfo>,
 }
@@ -24,6 +25,7 @@ impl AllAllowancesResponse {
 }
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
+#[serde(crate = "sylvia::serde")]
 pub struct AllowanceInfo {
     pub spender: Addr,
     pub balance: NativeBalance,
@@ -74,17 +76,19 @@ impl AllowanceInfo {
 }
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, Eq, JsonSchema, Debug, Default)]
+#[serde(crate = "sylvia::serde")]
 pub struct AllPermissionsResponse {
     pub permissions: Vec<PermissionsInfo>,
 }
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, Eq, JsonSchema, Debug)]
+#[serde(crate = "sylvia::serde")]
 pub struct PermissionsInfo {
     pub spender: Addr,
     pub permissions: Permissions,
 }
 
-#[cfg(any(test, feature = "test-utils"))]
+#[cfg(any(test, feature = "mt"))]
 impl PermissionsInfo {
     /// Utility function providing some ordering to be used with `slice::sort_by`.
     ///

--- a/examples/contracts/cw1-subkeys/src/state.rs
+++ b/examples/contracts/cw1-subkeys/src/state.rs
@@ -1,8 +1,8 @@
 use core::fmt;
 
 use cw_utils::{Expiration, NativeBalance};
-use serde::{Deserialize, Serialize};
 use sylvia::schemars;
+use sylvia::serde::{Deserialize, Serialize};
 
 // Permissions struct defines users message execution permissions.
 // Could have implemented permissions for each cosmos module(StakingPermissions, GovPermissions etc...)
@@ -11,6 +11,7 @@ use sylvia::schemars;
 #[derive(
     Serialize, Deserialize, Clone, Debug, PartialEq, Eq, schemars::JsonSchema, Default, Copy,
 )]
+#[serde(crate = "sylvia::serde")]
 pub struct Permissions {
     pub delegate: bool,
     pub redelegate: bool,
@@ -29,6 +30,7 @@ impl fmt::Display for Permissions {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, schemars::JsonSchema, Default)]
+#[serde(crate = "sylvia::serde")]
 pub struct Allowance {
     pub balance: NativeBalance,
     pub expires: Expiration,

--- a/examples/contracts/cw1-whitelist/Cargo.toml
+++ b/examples/contracts/cw1-whitelist/Cargo.toml
@@ -13,21 +13,18 @@ crate-type = ["cdylib", "rlib"]
 
 [features]
 library = []
-mt = ["sylvia/mt", "library", "cw-multi-test", "anyhow"]
+mt = ["sylvia/mt", "library", "anyhow"]
 
 [dependencies]
-serde = { workspace = true }
 sylvia = { path = "../../../sylvia" }
 cw1 = { path = "../../interfaces/cw1" }
 whitelist = { path = "../../interfaces/whitelist" }
 cw-storage-plus = { workspace = true }
 thiserror = { workspace = true }
 cw2 = { workspace = true }
-cw-multi-test = { workspace = true, optional = true }
 anyhow = { workspace = true, optional = true }
 
 [dev-dependencies]
 anyhow = { workspace = true }
-cw-multi-test = { workspace = true }
 assert_matches = { workspace = true }
 sylvia = { path = "../../../sylvia", features = ["mt"] }

--- a/examples/contracts/cw1-whitelist/src/bin/schema.rs
+++ b/examples/contracts/cw1-whitelist/src/bin/schema.rs
@@ -2,7 +2,6 @@ use cw1_whitelist::contract::sv::{ContractExecMsg, ContractQueryMsg, Instantiate
 use sylvia::cw_schema::write_api;
 use sylvia::cw_std::Empty;
 
-#[cfg(not(tarpaulin_include))]
 fn main() {
     write_api! {
         crate_name: sylvia::cw_schema,

--- a/examples/contracts/cw1-whitelist/src/contract.rs
+++ b/examples/contracts/cw1-whitelist/src/contract.rs
@@ -1,9 +1,9 @@
 use crate::error::ContractError;
 use cw2::set_contract_version;
 use cw_storage_plus::{Item, Map};
+use sylvia::contract;
 use sylvia::cw_std::{Addr, Deps, Empty, Response};
 use sylvia::types::{CustomMsg, CustomQuery, InstantiateCtx};
-use sylvia::{contract, schemars};
 
 #[cfg(not(feature = "library"))]
 use sylvia::entry_points;
@@ -63,7 +63,7 @@ where
 mod tests {
     use super::*;
     use cw1::Cw1;
-    use cw_multi_test::{IntoAddr, IntoBech32};
+    use sylvia::cw_multi_test::{IntoAddr, IntoBech32};
     use sylvia::cw_std::testing::{message_info, mock_dependencies, mock_env};
     use sylvia::cw_std::{
         coin, coins, to_json_binary, BankMsg, CosmosMsg, StakingMsg, SubMsg, WasmMsg,

--- a/examples/contracts/cw1-whitelist/src/multitest.rs
+++ b/examples/contracts/cw1-whitelist/src/multitest.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod test {
-    use cw_multi_test::IntoBech32;
+    use sylvia::cw_multi_test::IntoBech32;
     use sylvia::cw_std::{to_json_binary, Addr, WasmMsg};
     use whitelist::responses::AdminListResponse;
 

--- a/examples/contracts/cw20-base/Cargo.toml
+++ b/examples/contracts/cw20-base/Cargo.toml
@@ -13,11 +13,10 @@ crate-type = ["cdylib", "rlib"]
 
 [features]
 library = []
-mt = ["library", "cw-multi-test", "anyhow"]
+mt = ["library", "sylvia/mt", "anyhow"]
 
 [dependencies]
 anyhow = { workspace = true, optional = true }
-cw-multi-test = { workspace = true, optional = true }
 cw-storage-plus = { workspace = true }
 cw-utils = { workspace = true }
 cw2 = { workspace = true }
@@ -25,14 +24,12 @@ cw20-allowances = { path = "../../interfaces/cw20-allowances" }
 cw20-marketing = { path = "../../interfaces/cw20-marketing" }
 cw20-minting = { path = "../../interfaces/cw20-minting" }
 semver = { workspace = true }
-serde = { workspace = true }
 sylvia = { path = "../../../sylvia" }
 thiserror = { workspace = true }
 
 [dev-dependencies]
 anyhow = { workspace = true }
 assert_matches = { workspace = true }
-cw-multi-test = { workspace = true }
 cw-utils = { workspace = true }
 sylvia = { path = "../../../sylvia", features = ["mt"] }
 cw20-allowances = { path = "../../interfaces/cw20-allowances", features = [

--- a/examples/contracts/cw20-base/src/bin/schema.rs
+++ b/examples/contracts/cw20-base/src/bin/schema.rs
@@ -2,7 +2,6 @@ use cw20_base::contract::sv::{ContractExecMsg, ContractQueryMsg, InstantiateMsg}
 use sylvia::cw_schema::write_api;
 use sylvia::cw_std::Empty;
 
-#[cfg(not(tarpaulin_include))]
 fn main() {
     write_api! {
         crate_name: sylvia::cw_schema,

--- a/examples/contracts/cw20-base/src/contract.rs
+++ b/examples/contracts/cw20-base/src/contract.rs
@@ -7,14 +7,16 @@ use cw20_marketing::responses::{LogoInfo, MarketingInfoResponse};
 use cw20_marketing::Logo;
 use cw20_minting::responses::MinterResponse;
 use cw_storage_plus::{Item, Map};
+use sylvia::contract;
 use sylvia::cw_schema::cw_serde;
 use sylvia::cw_std::{
-    ensure, Addr, Binary, BlockInfo, DepsMut, Empty, Order, Response, StdError, StdResult, Storage,
+    ensure, Addr, Binary, BlockInfo, DepsMut, Order, Response, StdError, StdResult, Storage,
     Uint128,
 };
 use sylvia::types::{CustomMsg, CustomQuery, ExecCtx, InstantiateCtx, MigrateCtx, QueryCtx};
-use sylvia::{contract, schemars};
 
+#[cfg(not(feature = "library"))]
+use sylvia::cw_std::Empty;
 #[cfg(not(feature = "library"))]
 use sylvia::entry_points;
 

--- a/examples/contracts/cw20-base/src/multitest/allowances_tests.rs
+++ b/examples/contracts/cw20-base/src/multitest/allowances_tests.rs
@@ -2,8 +2,8 @@ use cw20_allowances::responses::{
     AllAllowancesResponse, AllSpenderAllowancesResponse, AllowanceInfo, AllowanceResponse,
     SpenderAllowanceInfo,
 };
-use cw_multi_test::{next_block, IntoBech32};
 use cw_utils::Expiration;
+use sylvia::cw_multi_test::{next_block, IntoBech32};
 use sylvia::cw_std::{Binary, StdError, Timestamp, Uint128};
 use sylvia::multitest::App;
 

--- a/examples/contracts/cw20-base/src/multitest/base_tests.rs
+++ b/examples/contracts/cw20-base/src/multitest/base_tests.rs
@@ -1,6 +1,6 @@
 use cw20_allowances::responses::{AllAllowancesResponse, SpenderAllowanceInfo};
-use cw_multi_test::IntoBech32;
 use cw_utils::Expiration;
+use sylvia::cw_multi_test::IntoBech32;
 use sylvia::cw_std::{Binary, StdError, Uint128};
 use sylvia::multitest::App;
 

--- a/examples/contracts/cw20-base/src/multitest/marketing_tests.rs
+++ b/examples/contracts/cw20-base/src/multitest/marketing_tests.rs
@@ -1,6 +1,6 @@
 use cw20_marketing::responses::{DownloadLogoResponse, LogoInfo, MarketingInfoResponse};
 use cw20_marketing::{EmbeddedLogo, Logo};
-use cw_multi_test::IntoBech32;
+use sylvia::cw_multi_test::IntoBech32;
 use sylvia::cw_std::{Addr, StdError};
 use sylvia::multitest::App;
 

--- a/examples/contracts/cw20-base/src/multitest/minting_tests.rs
+++ b/examples/contracts/cw20-base/src/multitest/minting_tests.rs
@@ -1,5 +1,5 @@
 use cw20_minting::responses::MinterResponse;
-use cw_multi_test::IntoBech32;
+use sylvia::cw_multi_test::IntoBech32;
 use sylvia::cw_std::{Addr, StdError, Uint128};
 use sylvia::multitest::App;
 

--- a/examples/contracts/cw20-base/src/multitest/receiver_contract.rs
+++ b/examples/contracts/cw20-base/src/multitest/receiver_contract.rs
@@ -1,6 +1,6 @@
+use sylvia::contract;
 use sylvia::cw_std::{Response, StdResult};
 use sylvia::types::InstantiateCtx;
-use sylvia::{contract, schemars};
 
 use super::receiver;
 pub struct ReceiverContract {}

--- a/examples/contracts/entry-points-overriding/Cargo.toml
+++ b/examples/contracts/entry-points-overriding/Cargo.toml
@@ -13,17 +13,15 @@ crate-type = ["cdylib", "rlib"]
 
 [features]
 library = []
-mt = ["library", "cw-multi-test", "anyhow"]
+mt = ["library", "sylvia/mt", "anyhow"]
 
 [dependencies]
 anyhow = { workspace = true, optional = true }
 cw-multi-test = { workspace = true, optional = true }
 cw-storage-plus = { workspace = true }
 cw-utils = { workspace = true }
-serde = { workspace = true }
 sylvia = { path = "../../../sylvia" }
 
 [dev-dependencies]
 anyhow = { workspace = true }
-cw-multi-test = { workspace = true }
 sylvia = { path = "../../../sylvia", features = ["mt"] }

--- a/examples/contracts/entry-points-overriding/src/bin/schema.rs
+++ b/examples/contracts/entry-points-overriding/src/bin/schema.rs
@@ -3,7 +3,6 @@ use sylvia::cw_schema::write_api;
 use entry_points_overriding::contract::sv::{ContractQueryMsg, InstantiateMsg};
 use entry_points_overriding::messages::{CustomExecMsg, SudoMsg};
 
-#[cfg(not(tarpaulin_include))]
 fn main() {
     write_api! {
         crate_name: sylvia::cw_schema,

--- a/examples/contracts/entry-points-overriding/src/contract.rs
+++ b/examples/contracts/entry-points-overriding/src/contract.rs
@@ -1,7 +1,7 @@
 use cw_storage_plus::Item;
+use sylvia::contract;
 use sylvia::cw_std::{Response, StdError, StdResult};
 use sylvia::types::{ExecCtx, InstantiateCtx, QueryCtx};
-use sylvia::{contract, schemars};
 
 #[cfg(not(feature = "library"))]
 use sylvia::entry_points;

--- a/examples/contracts/entry-points-overriding/src/lib.rs
+++ b/examples/contracts/entry-points-overriding/src/lib.rs
@@ -1,5 +1,5 @@
 pub mod contract;
 pub mod entry_points;
 pub mod messages;
-#[cfg(any(test, feature = "tests"))]
+#[cfg(test)]
 pub mod multitest;

--- a/examples/contracts/entry-points-overriding/src/multitest.rs
+++ b/examples/contracts/entry-points-overriding/src/multitest.rs
@@ -3,7 +3,7 @@ mod test {
     use crate::contract::sv::mt::{CodeId, CounterContractProxy};
     use crate::contract::sv::{ContractExecMsg, ExecMsg};
     use crate::messages::{CustomExecMsg, SudoMsg, UserExecMsg};
-    use cw_multi_test::{Executor, IntoBech32};
+    use sylvia::cw_multi_test::{Executor, IntoBech32};
     use sylvia::cw_std::Addr;
     use sylvia::multitest::App;
 

--- a/examples/contracts/generic_contract/Cargo.toml
+++ b/examples/contracts/generic_contract/Cargo.toml
@@ -13,14 +13,12 @@ crate-type = ["cdylib", "rlib"]
 
 [features]
 library = []
-mt = ["library", "cw-multi-test", "anyhow"]
+mt = ["library", "sylvia/mt", "anyhow"]
 
 [dependencies]
 anyhow = { workspace = true, optional = true }
-cw-multi-test = { workspace = true, optional = true }
 cw-storage-plus = { workspace = true }
 cw-utils = { workspace = true }
-serde = { workspace = true }
 sylvia = { path = "../../../sylvia" }
 cw1 = { path = "../../interfaces/cw1" }
 generic = { path = "../../interfaces/generic" }
@@ -28,5 +26,4 @@ custom-and-generic = { path = "../../interfaces/custom-and-generic" }
 
 [dev-dependencies]
 anyhow = { workspace = true }
-cw-multi-test = { workspace = true }
 sylvia = { path = "../../../sylvia", features = ["mt"] }

--- a/examples/contracts/generic_contract/src/bin/schema.rs
+++ b/examples/contracts/generic_contract/src/bin/schema.rs
@@ -1,6 +1,5 @@
 use sylvia::cw_schema::write_api;
 
-#[cfg(not(tarpaulin_include))]
 fn main() {
     use generic_contract::contract::sv::{ContractExecMsg, ContractQueryMsg, InstantiateMsg};
     use generic_contract::contract::SvCustomMsg;

--- a/examples/contracts/generic_contract/src/contract.rs
+++ b/examples/contracts/generic_contract/src/contract.rs
@@ -1,8 +1,8 @@
 use cw_storage_plus::Item;
-use serde::Deserialize;
+use sylvia::contract;
 use sylvia::cw_std::{Reply, Response, StdResult};
+use sylvia::serde::Deserialize;
 use sylvia::types::{CustomMsg, ExecCtx, InstantiateCtx, MigrateCtx, QueryCtx, ReplyCtx, SudoCtx};
-use sylvia::{contract, schemars};
 
 #[cfg(not(feature = "library"))]
 use sylvia::entry_points;
@@ -196,12 +196,12 @@ mod tests {
     use super::sv::mt::CodeId;
     use super::{GenericContract, SvCustomMsg, SvCustomQuery};
     use crate::contract::sv::mt::GenericContractProxy;
-    use cw_multi_test::IntoBech32;
+    use sylvia::cw_multi_test::{BasicApp, IntoBech32};
     use sylvia::multitest::App;
 
     #[test]
     fn generic_contract() {
-        let app = App::<cw_multi_test::BasicApp<SvCustomMsg, SvCustomQuery>>::custom(|_, _, _| {});
+        let app = App::<BasicApp<SvCustomMsg, SvCustomQuery>>::custom(|_, _, _| {});
         #[allow(clippy::type_complexity)]
         let code_id: CodeId<
             GenericContract<

--- a/examples/contracts/generic_contract/src/custom_and_generic.rs
+++ b/examples/contracts/generic_contract/src/custom_and_generic.rs
@@ -107,12 +107,12 @@ mod tests {
     use super::{GenericContract, SvCustomMsg, SvCustomQuery};
     use crate::contract::sv::mt::CodeId;
     use custom_and_generic::sv::mt::CustomAndGenericProxy;
-    use cw_multi_test::IntoBech32;
+    use sylvia::cw_multi_test::{BasicApp, IntoBech32};
     use sylvia::multitest::App;
 
     #[test]
     fn proxy_methods() {
-        let app = App::<cw_multi_test::BasicApp<SvCustomMsg, SvCustomQuery>>::custom(|_, _, _| {});
+        let app = App::<BasicApp<SvCustomMsg, SvCustomQuery>>::custom(|_, _, _| {});
         let code_id = CodeId::<
             GenericContract<
                 SvCustomMsg,

--- a/examples/contracts/generic_contract/src/cw1.rs
+++ b/examples/contracts/generic_contract/src/cw1.rs
@@ -55,13 +55,13 @@ mod tests {
     use crate::contract::sv::mt::CodeId;
     use crate::contract::{GenericContract, SvCustomMsg, SvCustomQuery};
     use cw1::sv::mt::Cw1Proxy;
-    use cw_multi_test::IntoBech32;
+    use sylvia::cw_multi_test::{BasicApp, IntoBech32};
     use sylvia::cw_std::{CosmosMsg, Empty};
     use sylvia::multitest::App;
 
     #[test]
     fn proxy_methods() {
-        let app = App::<cw_multi_test::BasicApp<SvCustomMsg, SvCustomQuery>>::custom(|_, _, _| {});
+        let app = App::<BasicApp<SvCustomMsg, SvCustomQuery>>::custom(|_, _, _| {});
         let code_id = CodeId::<
             GenericContract<
                 SvCustomMsg,

--- a/examples/contracts/generic_contract/src/generic.rs
+++ b/examples/contracts/generic_contract/src/generic.rs
@@ -1,6 +1,6 @@
 use generic::Generic;
-use serde::Deserialize;
 use sylvia::cw_std::{CosmosMsg, Response, StdError, StdResult};
+use sylvia::serde::Deserialize;
 use sylvia::types::{CustomMsg, ExecCtx, QueryCtx, SudoCtx};
 
 use crate::contract::{GenericContract, SvCustomMsg};
@@ -118,14 +118,16 @@ where
 mod tests {
     use crate::contract::sv::mt::CodeId;
     use crate::contract::{GenericContract, SvCustomMsg, SvCustomQuery};
-    use cw_multi_test::IntoBech32;
     use generic::sv::mt::GenericProxy;
+    use sylvia::cw_multi_test::IntoBech32;
     use sylvia::cw_std::CosmosMsg;
     use sylvia::multitest::App;
 
     #[test]
     fn proxy_methods() {
-        let app = App::<cw_multi_test::BasicApp<SvCustomMsg, SvCustomQuery>>::custom(|_, _, _| {});
+        let app = App::<sylvia::cw_multi_test::BasicApp<SvCustomMsg, SvCustomQuery>>::custom(
+            |_, _, _| {},
+        );
         #[allow(clippy::type_complexity)]
         let code_id: CodeId<
             GenericContract<

--- a/examples/contracts/generic_iface_on_contract/Cargo.toml
+++ b/examples/contracts/generic_iface_on_contract/Cargo.toml
@@ -13,14 +13,12 @@ crate-type = ["cdylib", "rlib"]
 
 [features]
 library = []
-mt = ["library", "cw-multi-test", "anyhow"]
+mt = ["library", "sylvia/mt", "anyhow"]
 
 [dependencies]
 anyhow = { workspace = true, optional = true }
-cw-multi-test = { workspace = true, optional = true }
 cw-storage-plus = { workspace = true }
 cw-utils = { workspace = true }
-serde = { workspace = true }
 sylvia = { path = "../../../sylvia" }
 cw1 = { path = "../../interfaces/cw1" }
 generic = { path = "../../interfaces/generic" }
@@ -28,5 +26,4 @@ custom-and-generic = { path = "../../interfaces/custom-and-generic" }
 
 [dev-dependencies]
 anyhow = { workspace = true }
-cw-multi-test = { workspace = true }
 sylvia = { path = "../../../sylvia", features = ["mt"] }

--- a/examples/contracts/generic_iface_on_contract/src/bin/schema.rs
+++ b/examples/contracts/generic_iface_on_contract/src/bin/schema.rs
@@ -1,6 +1,5 @@
 use sylvia::cw_schema::write_api;
 
-#[cfg(not(tarpaulin_include))]
 fn main() {
     use generic_iface_on_contract::contract::sv::{
         ContractExecMsg, ContractQueryMsg, InstantiateMsg,

--- a/examples/contracts/generic_iface_on_contract/src/contract.rs
+++ b/examples/contracts/generic_iface_on_contract/src/contract.rs
@@ -1,6 +1,6 @@
+use sylvia::contract;
 use sylvia::cw_std::{Response, StdResult};
 use sylvia::types::InstantiateCtx;
-use sylvia::{contract, schemars};
 
 #[cfg(not(feature = "library"))]
 use sylvia::entry_points;
@@ -39,7 +39,7 @@ impl NonGenericContract {
 #[cfg(test)]
 mod tests {
     use super::{SvCustomMsg, SvCustomQuery};
-    use cw_multi_test::IntoBech32;
+    use sylvia::cw_multi_test::{BasicApp, IntoBech32};
     use sylvia::cw_std::{CosmosMsg, Empty};
     use sylvia::multitest::App;
 
@@ -51,7 +51,7 @@ mod tests {
     #[test]
     fn mt_helpers() {
         let _ = NonGenericContract::new();
-        let app = App::<cw_multi_test::BasicApp<SvCustomMsg, SvCustomQuery>>::custom(|_, _, _| {});
+        let app = App::<BasicApp<SvCustomMsg, SvCustomQuery>>::custom(|_, _, _| {});
         let code_id = super::sv::mt::CodeId::store_code(&app);
 
         let owner = "owner".into_bech32();

--- a/examples/contracts/generics_forwarded/Cargo.toml
+++ b/examples/contracts/generics_forwarded/Cargo.toml
@@ -13,14 +13,12 @@ crate-type = ["cdylib", "rlib"]
 
 [features]
 library = []
-mt = ["library", "cw-multi-test", "anyhow"]
+mt = ["library", "sylvia/mt", "anyhow"]
 
 [dependencies]
 anyhow = { workspace = true, optional = true }
-cw-multi-test = { workspace = true, optional = true }
 cw-storage-plus = { workspace = true }
 cw-utils = { workspace = true }
-serde = { workspace = true }
 sylvia = { path = "../../../sylvia" }
 generic = { path = "../../interfaces/generic" }
 custom-and-generic = { path = "../../interfaces/custom-and-generic/" }
@@ -29,5 +27,4 @@ thiserror = { workspace = true }
 
 [dev-dependencies]
 anyhow = { workspace = true }
-cw-multi-test = { workspace = true }
 sylvia = { path = "../../../sylvia", features = ["mt"] }

--- a/examples/contracts/generics_forwarded/src/bin/schema.rs
+++ b/examples/contracts/generics_forwarded/src/bin/schema.rs
@@ -1,6 +1,5 @@
 use sylvia::cw_schema::write_api;
 
-#[cfg(not(tarpaulin_include))]
 fn main() {
     use generics_forwarded::contract::sv::{ContractExecMsg, ContractQueryMsg, InstantiateMsg};
     use generics_forwarded::contract::{SvCustomMsg, SvCustomQuery};

--- a/examples/contracts/generics_forwarded/src/contract.rs
+++ b/examples/contracts/generics_forwarded/src/contract.rs
@@ -1,11 +1,11 @@
 use crate::error::ContractError;
 use cw_storage_plus::Item;
-use serde::Deserialize;
+use sylvia::contract;
 use sylvia::cw_std::{Reply, Response};
+use sylvia::serde::Deserialize;
 use sylvia::types::{
     CustomMsg, CustomQuery, ExecCtx, InstantiateCtx, MigrateCtx, QueryCtx, ReplyCtx, SudoCtx,
 };
-use sylvia::{contract, schemars};
 
 #[sylvia::cw_schema::cw_serde(crate = "sylvia::cw_schema")]
 pub struct SvCustomMsg;
@@ -206,12 +206,12 @@ mod tests {
     use super::sv::mt::CodeId;
     use super::{GenericsForwardedContract, SvCustomMsg, SvCustomQuery};
     use crate::contract::sv::mt::GenericsForwardedContractProxy;
-    use cw_multi_test::IntoBech32;
+    use sylvia::cw_multi_test::{BasicApp, IntoBech32};
     use sylvia::multitest::App;
 
     #[test]
     fn generic_contract() {
-        let app = App::<cw_multi_test::BasicApp<SvCustomMsg, SvCustomQuery>>::custom(|_, _, _| {});
+        let app = App::<BasicApp<SvCustomMsg, SvCustomQuery>>::custom(|_, _, _| {});
         #[allow(clippy::type_complexity)]
         let code_id: CodeId<
             GenericsForwardedContract<

--- a/examples/contracts/generics_forwarded/src/custom_and_generic.rs
+++ b/examples/contracts/generics_forwarded/src/custom_and_generic.rs
@@ -1,6 +1,6 @@
 use custom_and_generic::CustomAndGeneric;
-use serde::Deserialize;
 use sylvia::cw_std::{CosmosMsg, Response};
+use sylvia::serde::Deserialize;
 use sylvia::types::{CustomMsg, CustomQuery, ExecCtx, QueryCtx, SudoCtx};
 
 use crate::contract::{GenericsForwardedContract, SvCustomMsg};
@@ -128,13 +128,13 @@ mod tests {
     use crate::contract::sv::mt::CodeId;
     use crate::contract::{GenericsForwardedContract, SvCustomMsg, SvCustomQuery};
     use custom_and_generic::sv::mt::CustomAndGenericProxy;
-    use cw_multi_test::IntoBech32;
+    use sylvia::cw_multi_test::{BasicApp, IntoBech32};
     use sylvia::cw_std::CosmosMsg;
     use sylvia::multitest::App;
 
     #[test]
     fn proxy_methods() {
-        let app = App::<cw_multi_test::BasicApp<SvCustomMsg, SvCustomQuery>>::custom(|_, _, _| {});
+        let app = App::<BasicApp<SvCustomMsg, SvCustomQuery>>::custom(|_, _, _| {});
         let code_id = CodeId::<
             GenericsForwardedContract<
                 SvCustomMsg,

--- a/examples/contracts/generics_forwarded/src/cw1.rs
+++ b/examples/contracts/generics_forwarded/src/cw1.rs
@@ -1,8 +1,8 @@
 use cw1::{CanExecuteResp, Cw1};
-use serde::de::DeserializeOwned;
-use serde::Deserialize;
 use sylvia::cw_schema::schemars::JsonSchema;
 use sylvia::cw_std::{CosmosMsg, CustomMsg, Empty, Response, StdResult};
+use sylvia::serde::de::DeserializeOwned;
+use sylvia::serde::Deserialize;
 use sylvia::types::{CustomQuery, ExecCtx, QueryCtx};
 
 use crate::contract::GenericsForwardedContract;
@@ -79,13 +79,13 @@ mod tests {
     use crate::contract::sv::mt::CodeId;
     use crate::contract::{GenericsForwardedContract, SvCustomMsg, SvCustomQuery};
     use cw1::sv::mt::Cw1Proxy;
-    use cw_multi_test::IntoBech32;
+    use sylvia::cw_multi_test::{BasicApp, IntoBech32};
     use sylvia::cw_std::{CosmosMsg, Empty};
     use sylvia::multitest::App;
 
     #[test]
     fn proxy_methods() {
-        let app = App::<cw_multi_test::BasicApp<SvCustomMsg, SvCustomQuery>>::custom(|_, _, _| {});
+        let app = App::<BasicApp<SvCustomMsg, SvCustomQuery>>::custom(|_, _, _| {});
         let code_id = CodeId::<
             GenericsForwardedContract<
                 SvCustomMsg,

--- a/examples/contracts/generics_forwarded/src/generic.rs
+++ b/examples/contracts/generics_forwarded/src/generic.rs
@@ -1,6 +1,6 @@
 use generic::Generic;
-use serde::Deserialize;
 use sylvia::cw_std::{CosmosMsg, Response};
+use sylvia::serde::Deserialize;
 use sylvia::types::{CustomMsg, CustomQuery, ExecCtx, QueryCtx, SudoCtx};
 
 use crate::contract::{GenericsForwardedContract, SvCustomMsg};
@@ -125,14 +125,14 @@ where
 mod tests {
     use crate::contract::sv::mt::CodeId;
     use crate::contract::{GenericsForwardedContract, SvCustomMsg, SvCustomQuery};
-    use cw_multi_test::IntoBech32;
     use generic::sv::mt::GenericProxy;
+    use sylvia::cw_multi_test::{BasicApp, IntoBech32};
     use sylvia::cw_std::CosmosMsg;
     use sylvia::multitest::App;
 
     #[test]
     fn proxy_methods() {
-        let app = App::<cw_multi_test::BasicApp<SvCustomMsg, SvCustomQuery>>::custom(|_, _, _| {});
+        let app = App::<BasicApp<SvCustomMsg, SvCustomQuery>>::custom(|_, _, _| {});
         #[allow(clippy::type_complexity)]
         let code_id: CodeId<
             GenericsForwardedContract<

--- a/examples/interfaces/custom-and-generic/Cargo.toml
+++ b/examples/interfaces/custom-and-generic/Cargo.toml
@@ -12,9 +12,8 @@ homepage = "https://cosmwasm.com"
 mt = ["sylvia/mt"]
 
 [dependencies]
-serde = { workspace = true }
 sylvia = { path = "../../../sylvia" }
 
 [dev-dependencies]
 anyhow = { workspace = true }
-cw-multi-test = { workspace = true }
+sylvia = { path = "../../../sylvia", features = ["mt"] }

--- a/examples/interfaces/cw1/Cargo.toml
+++ b/examples/interfaces/cw1/Cargo.toml
@@ -12,9 +12,8 @@ homepage = "https://cosmwasm.com"
 mt = ["sylvia/mt"]
 
 [dependencies]
-serde = { workspace = true }
 sylvia = { path = "../../../sylvia" }
 
 [dev-dependencies]
 anyhow = { workspace = true }
-cw-multi-test = { workspace = true }
+sylvia = { path = "../../../sylvia", features = ["mt"] }

--- a/examples/interfaces/cw1/src/lib.rs
+++ b/examples/interfaces/cw1/src/lib.rs
@@ -1,11 +1,12 @@
-use serde::{Deserialize, Serialize};
 use sylvia::cw_std::{CosmosMsg, Response, StdError, StdResult};
+use sylvia::serde::{Deserialize, Serialize};
 use sylvia::types::{CustomMsg, CustomQuery, ExecCtx, QueryCtx};
 use sylvia::{interface, schemars};
 
 #[derive(
     Serialize, Deserialize, Clone, PartialEq, Eq, sylvia::schemars::JsonSchema, Debug, Default,
 )]
+#[serde(crate = "sylvia::serde")]
 pub struct CanExecuteResp {
     pub can_execute: bool,
 }

--- a/examples/interfaces/cw20-allowances/Cargo.toml
+++ b/examples/interfaces/cw20-allowances/Cargo.toml
@@ -12,10 +12,9 @@ homepage = "https://cosmwasm.com"
 mt = ["sylvia/mt"]
 
 [dependencies]
-serde = { workspace = true }
 sylvia = { path = "../../../sylvia" }
 cw-utils = { workspace = true }
 
 [dev-dependencies]
 anyhow = { workspace = true }
-cw-multi-test = { workspace = true }
+sylvia = { path = "../../../sylvia", features = ["mt"] }

--- a/examples/interfaces/cw20-allowances/src/responses.rs
+++ b/examples/interfaces/cw20-allowances/src/responses.rs
@@ -1,11 +1,12 @@
 use cw_utils::Expiration;
-use serde::{Deserialize, Serialize};
 use sylvia::cw_schema::cw_serde;
 use sylvia::cw_std::Uint128;
 use sylvia::schemars::JsonSchema;
+use sylvia::serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug, Default)]
 #[schemars(crate = "sylvia::cw_schema::schemars")]
+#[serde(crate = "sylvia::serde")]
 pub struct AllowanceResponse {
     pub allowance: Uint128,
     pub expires: Expiration,
@@ -20,6 +21,7 @@ pub struct AllowanceInfo {
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug, Default)]
 #[schemars(crate = "sylvia::cw_schema::schemars")]
+#[serde(crate = "sylvia::serde")]
 pub struct AllAllowancesResponse {
     pub allowances: Vec<AllowanceInfo>,
 }
@@ -33,12 +35,14 @@ pub struct SpenderAllowanceInfo {
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug, Default)]
 #[schemars(crate = "sylvia::cw_schema::schemars")]
+#[serde(crate = "sylvia::serde")]
 pub struct AllSpenderAllowancesResponse {
     pub allowances: Vec<SpenderAllowanceInfo>,
 }
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, Eq, JsonSchema, Debug, Default)]
 #[schemars(crate = "sylvia::cw_schema::schemars")]
+#[serde(crate = "sylvia::serde")]
 pub struct AllAccountsResponse {
     pub accounts: Vec<String>,
 }

--- a/examples/interfaces/cw20-marketing/Cargo.toml
+++ b/examples/interfaces/cw20-marketing/Cargo.toml
@@ -12,9 +12,8 @@ homepage = "https://cosmwasm.com"
 mt = ["sylvia/mt"]
 
 [dependencies]
-serde = { workspace = true }
 sylvia = { path = "../../../sylvia" }
 
 [dev-dependencies]
 anyhow = { workspace = true }
-cw-multi-test = { workspace = true }
+sylvia = { path = "../../../sylvia", features = ["mt"] }

--- a/examples/interfaces/cw20-marketing/src/responses.rs
+++ b/examples/interfaces/cw20-marketing/src/responses.rs
@@ -1,7 +1,7 @@
-use serde::{Deserialize, Serialize};
 use sylvia::cw_schema::cw_serde;
 use sylvia::cw_std::{Addr, Binary};
 use sylvia::schemars;
+use sylvia::serde::{Deserialize, Serialize};
 
 /// This is used to display logo info, provide a link or inform there is one
 /// that can be downloaded from the blockchain itself
@@ -14,6 +14,7 @@ pub enum LogoInfo {
 }
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, schemars::JsonSchema, Debug, Default)]
+#[serde(crate = "sylvia::serde")]
 pub struct MarketingInfoResponse {
     /// A URL pointing to the project behind this token.
     pub project: Option<String>,

--- a/examples/interfaces/cw20-minting/Cargo.toml
+++ b/examples/interfaces/cw20-minting/Cargo.toml
@@ -12,9 +12,8 @@ homepage = "https://cosmwasm.com"
 mt = ["sylvia/mt"]
 
 [dependencies]
-serde = { workspace = true }
 sylvia = { path = "../../../sylvia" }
 
 [dev-dependencies]
 anyhow = { workspace = true }
-cw-multi-test = { workspace = true }
+sylvia = { path = "../../../sylvia", features = ["mt"] }

--- a/examples/interfaces/cw4/Cargo.toml
+++ b/examples/interfaces/cw4/Cargo.toml
@@ -12,9 +12,8 @@ homepage = "https://cosmwasm.com"
 mt = ["sylvia/mt"]
 
 [dependencies]
-serde = { workspace = true }
 sylvia = { path = "../../../sylvia" }
 
 [dev-dependencies]
 anyhow = { workspace = true }
-cw-multi-test = { workspace = true }
+sylvia = { path = "../../../sylvia", features = ["mt"] }

--- a/examples/interfaces/generic/Cargo.toml
+++ b/examples/interfaces/generic/Cargo.toml
@@ -12,9 +12,8 @@ homepage = "https://cosmwasm.com"
 mt = ["sylvia/mt"]
 
 [dependencies]
-serde = { workspace = true }
 sylvia = { path = "../../../sylvia" }
 
 [dev-dependencies]
 anyhow = { workspace = true }
-cw-multi-test = { workspace = true }
+sylvia = { path = "../../../sylvia", features = ["mt"] }

--- a/examples/interfaces/whitelist/Cargo.toml
+++ b/examples/interfaces/whitelist/Cargo.toml
@@ -12,9 +12,8 @@ homepage = "https://cosmwasm.com"
 mt = ["sylvia/mt"]
 
 [dependencies]
-serde = { workspace = true }
 sylvia = { path = "../../../sylvia" }
 
 [dev-dependencies]
 anyhow = { workspace = true }
-cw-multi-test = { workspace = true }
+sylvia = { path = "../../../sylvia", features = ["mt"] }

--- a/examples/interfaces/whitelist/src/responses.rs
+++ b/examples/interfaces/whitelist/src/responses.rs
@@ -1,13 +1,12 @@
-use serde::{Deserialize, Serialize};
-use sylvia::schemars;
+use sylvia::cw_schema::cw_serde;
 
-#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, schemars::JsonSchema, Debug, Default)]
+#[cw_serde(crate = "sylvia::cw_schema")]
 pub struct AdminListResponse {
     pub admins: Vec<String>,
     pub mutable: bool,
 }
 
-#[cfg(any(test, feature = "test-utils"))]
+#[cfg(any(test, feature = "mt"))]
 impl AdminListResponse {
     /// Utility function for converting message to its canonical form, so two messages with
     /// different representation but same semantical meaning can be easily compared.

--- a/sylvia-derive/src/contract/communication/struct_msg.rs
+++ b/sylvia-derive/src/contract/communication/struct_msg.rs
@@ -1,4 +1,3 @@
-use crate::crate_module;
 use crate::parser::attributes::MsgAttrForwarding;
 use crate::parser::variant_descs::AsVariantDescs;
 use crate::parser::{ContractErrorAttr, Custom, MsgType, ParsedSylviaAttributes};
@@ -74,8 +73,6 @@ impl<'a> StructMessage<'a> {
     }
 
     pub fn emit(&self) -> TokenStream {
-        let sylvia = crate_module();
-
         let Self {
             source,
             contract_type,
@@ -112,10 +109,11 @@ impl<'a> StructMessage<'a> {
         let fields = variant.fields().iter().map(MsgField::emit_pub);
 
         let msg_attrs_to_forward = msg_attrs_to_forward.iter().map(|attr| &attr.attrs);
+        let derive_call = variant.msg_type().emit_derive_call();
 
         quote! {
             #[allow(clippy::derive_partial_eq_without_eq)]
-            #[derive(#sylvia ::serde::Serialize, #sylvia ::serde::Deserialize, Clone, Debug, PartialEq, #sylvia ::schemars::JsonSchema)]
+            #derive_call
             #( #[ #msg_attrs_to_forward ] )*
             #[serde(rename_all="snake_case")]
             pub struct #name #bracketed_used_generics {

--- a/sylvia-derive/src/contract/communication/wrapper_msg.rs
+++ b/sylvia-derive/src/contract/communication/wrapper_msg.rs
@@ -116,11 +116,13 @@ impl<'a> GlueMessage<'a> {
 
         let modules_names = interfaces.variants_modules();
         let variants_names = interfaces.variants_names();
+        let serde = quote! { #sylvia:: serde }.to_string();
 
         quote! {
             #[allow(clippy::derive_partial_eq_without_eq)]
             #[derive(#sylvia ::serde::Serialize, Clone, Debug, PartialEq)]
             #[serde(rename_all="snake_case", untagged)]
+            #[serde(crate = #serde )]
             pub enum #contract_enum_name #bracketed_wrapper_generics #full_where_clause {
                 #(#variants,)*
                 #contract_variant
@@ -186,11 +188,11 @@ impl<'a> GlueMessage<'a> {
 
             #response_schemas
 
-            impl<'sv_de, #(#generics,)* > serde::Deserialize<'sv_de> for #contract_enum_name #bracketed_wrapper_generics #full_where_clause {
+            impl<'sv_de, #(#generics,)* > #sylvia ::serde::Deserialize<'sv_de> for #contract_enum_name #bracketed_wrapper_generics #full_where_clause {
                 fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-                    where D: serde::Deserializer<'sv_de>,
+                    where D: #sylvia ::serde::Deserializer<'sv_de>,
                 {
-                    use serde::de::Error;
+                    use #sylvia ::serde::de::Error;
 
                     let val = #sylvia ::serde_value::Value::deserialize(deserializer)?;
                     let map = match &val {

--- a/sylvia-derive/src/types/msg_type.rs
+++ b/sylvia-derive/src/types/msg_type.rs
@@ -157,16 +157,19 @@ impl MsgType {
         let sylvia = crate_module();
         let cw_schema = quote! { #sylvia:: cw_schema }.to_string();
         let schemars = quote! { #sylvia:: cw_schema::schemars }.to_string();
+        let serde = quote! { #sylvia:: serde }.to_string();
 
         match self {
             MsgType::Query => quote! {
                 #[derive(#sylvia ::serde::Serialize, #sylvia ::serde::Deserialize, Clone, Debug, PartialEq, #sylvia ::schemars::JsonSchema, #sylvia:: cw_schema::QueryResponses)]
                 #[schemars(crate = #schemars )]
                 #[query_responses(crate = #cw_schema )]
+                #[serde(crate = #serde )]
             },
             _ => quote! {
                 #[derive(#sylvia ::serde::Serialize, #sylvia ::serde::Deserialize, Clone, Debug, PartialEq, #sylvia ::schemars::JsonSchema)]
                 #[schemars(crate = #schemars )]
+                #[serde(crate = #serde )]
             },
         }
     }


### PR DESCRIPTION
Removed `serde` and `cw_multi_test` dependency from examples.
Fixed features in examples as some already non existent features were used in `cfg` checks. Also `mt` feature now enables `sylvia/mt` instead of `cw_multi_test`.
