### PR TITLE
Fix typo MIGRATING.md

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -65,7 +65,7 @@ ignored in the further process.
 +> = CodeId::store_code(&app);
 ```
 
-### Lifetime ellision in a contract's impl block not supported
+### Lifetime elision in a contract's impl block not supported
 
 ```diff
 -#[contract]


### PR DESCRIPTION
## Description

This pull request fixes a typo in the `MIGRATING.md` file:  
- Corrected "Lifetime ellision" to "Lifetime elision" in the section titled "Lifetime elision in a contract's impl block not supported."  

## Changes Made
- **File Modified**: `MIGRATING.md`
  - Fixed the typo in the documentation to improve clarity and professionalism.

## Rationale
Correct spelling in documentation ensures better readability and reflects the repository's quality standards.

## Checklist
- [x] Verified that the change is minor and does not affect functionality.
- [x] Reviewed the contributing guidelines to ensure compliance.

## Notes
- Contributions adhere to the repository's contributing guidelines.
- Allowing edits by maintainers for any required adjustments.

Feel free to suggest any additional edits or changes!
