### PR TITLE
feat: Fix parsing attribute macros without arguments in parentheses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1179,13 +1179,13 @@ dependencies = [
 
 [[package]]
 name = "sylvia-runtime-macros"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "220853b6e9134826eab438ebadca5e8943a10ea9f45209e29edf50e725ce7267"
+checksum = "e4e4c15b0f4cb3e31149f4d59bb13e095b880f2e2f087308f8577e30f123ecaa"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.101",
 ]
 
 [[package]]

--- a/sylvia-derive/Cargo.toml
+++ b/sylvia-derive/Cargo.toml
@@ -33,7 +33,7 @@ proc-macro-crate = "3.3.0"
 itertools = "0.14.0"
 
 [dev-dependencies]
-sylvia-runtime-macros = "0.6.0"
+sylvia-runtime-macros = "0.7.0"
 sylvia = { path = "../sylvia", features = [
     "mt",
     "stargate",


### PR DESCRIPTION
Prerequisities:
- Upgraded `sylvia-runtime-macros` to the newest version of `runtime_macros-derive` that uses **syn@2**.
- Published `sylvia-runtime-macros` **0.7.0**

This PR:
- Upgraded `sylvia-runtime-macros` dependency in `sylvia-derive`.
- This change fixes parsing attribute macros without arguments in parentheses.